### PR TITLE
Add City Search ViewModel and Unit Tests

### DIFF
--- a/lib/view_model/city_search_view_model.dart
+++ b/lib/view_model/city_search_view_model.dart
@@ -1,14 +1,20 @@
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:weather_app/repositories/weather_repository.dart';
+import 'package:weather_app/repositories/weather_repository_provider.dart';
 import 'package:weather_app/view_model/city_search_state.dart';
 
 // CitySearchViewModelは、都市検索に関連するビジネスロジックを処理するクラスです。
-class CitySearchViewModel extends StateNotifier<CitySearchState> {
+class CitySearchViewModel extends Notifier<CitySearchState> {
   // 天気情報を取得するためのリポジトリ
-  final WeatherRepository _weatherRepository;
+  late final WeatherRepository _weatherRepository;
 
-  // コンストラクタ。初期状態をCitySearchState()で設定します。
-  CitySearchViewModel(this._weatherRepository) : super(CitySearchState());
+  CitySearchViewModel();
+
+  @override
+  CitySearchState build() {
+    _weatherRepository = ref.read(weatherRepositoryProvider);
+    return CitySearchState();
+  }
 
   // ユーザーから入力された都市名を状態に更新するメソッド。
   void updateCityName(String cityName) {

--- a/lib/view_model/providers/city_search_view_model_provider.dart
+++ b/lib/view_model/providers/city_search_view_model_provider.dart
@@ -1,13 +1,9 @@
-import 'package:flutter_riverpod/flutter_riverpod.dart';
-import 'package:weather_app/repositories/weather_repository_provider.dart';
+import 'package:riverpod_annotation/riverpod_annotation.dart';
 import 'package:weather_app/view_model/city_search_state.dart';
 import 'package:weather_app/view_model/city_search_view_model.dart';
 
-// CitySearchViewModelのProvider定義
+// プロバイダー定義
 final citySearchViewModelProvider =
-    StateNotifierProvider<CitySearchViewModel, CitySearchState>((ref) {
-  // ref.watchを使ってWeatherRepositoryのインスタンスを取得
-  final weatherRepository = ref.watch(weatherRepositoryProvider);
-  // CitySearchViewModelにWeatherRepositoryを注入
-  return CitySearchViewModel(weatherRepository);
-});
+    NotifierProvider<CitySearchViewModel, CitySearchState>(
+  CitySearchViewModel.new,
+);

--- a/test/mocks/mock_city_search_view_model.mocks.dart
+++ b/test/mocks/mock_city_search_view_model.mocks.dart
@@ -5,11 +5,10 @@
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'dart:async' as _i5;
 
-import 'package:flutter_riverpod/flutter_riverpod.dart' as _i4;
+import 'package:flutter_riverpod/flutter_riverpod.dart' as _i2;
 import 'package:mockito/mockito.dart' as _i1;
-import 'package:state_notifier/state_notifier.dart' as _i6;
-import 'package:weather_app/view_model/city_search_state.dart' as _i2;
-import 'package:weather_app/view_model/city_search_view_model.dart' as _i3;
+import 'package:weather_app/view_model/city_search_state.dart' as _i3;
+import 'package:weather_app/view_model/city_search_view_model.dart' as _i4;
 
 // ignore_for_file: type=lint
 // ignore_for_file: avoid_redundant_argument_values
@@ -24,9 +23,20 @@ import 'package:weather_app/view_model/city_search_view_model.dart' as _i3;
 // ignore_for_file: camel_case_types
 // ignore_for_file: subtype_of_sealed_class
 
-class _FakeCitySearchState_0 extends _i1.SmartFake
-    implements _i2.CitySearchState {
-  _FakeCitySearchState_0(
+class _FakeNotifierProviderRef_0<T> extends _i1.SmartFake
+    implements _i2.NotifierProviderRef<T> {
+  _FakeNotifierProviderRef_0(
+    Object parent,
+    Invocation parentInvocation,
+  ) : super(
+          parent,
+          parentInvocation,
+        );
+}
+
+class _FakeCitySearchState_1 extends _i1.SmartFake
+    implements _i3.CitySearchState {
+  _FakeCitySearchState_1(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -39,43 +49,31 @@ class _FakeCitySearchState_0 extends _i1.SmartFake
 ///
 /// See the documentation for Mockito's code generation for more information.
 class MockCitySearchViewModel extends _i1.Mock
-    implements _i3.CitySearchViewModel {
+    implements _i4.CitySearchViewModel {
   MockCitySearchViewModel() {
     _i1.throwOnMissingStub(this);
   }
 
   @override
-  set onError(_i4.ErrorListener? _onError) => super.noSuchMethod(
-        Invocation.setter(
-          #onError,
-          _onError,
+  _i2.NotifierProviderRef<_i3.CitySearchState> get ref => (super.noSuchMethod(
+        Invocation.getter(#ref),
+        returnValue: _FakeNotifierProviderRef_0<_i3.CitySearchState>(
+          this,
+          Invocation.getter(#ref),
         ),
-        returnValueForMissingStub: null,
-      );
+      ) as _i2.NotifierProviderRef<_i3.CitySearchState>);
 
   @override
-  bool get mounted => (super.noSuchMethod(
-        Invocation.getter(#mounted),
-        returnValue: false,
-      ) as bool);
-
-  @override
-  _i5.Stream<_i2.CitySearchState> get stream => (super.noSuchMethod(
-        Invocation.getter(#stream),
-        returnValue: _i5.Stream<_i2.CitySearchState>.empty(),
-      ) as _i5.Stream<_i2.CitySearchState>);
-
-  @override
-  _i2.CitySearchState get state => (super.noSuchMethod(
+  _i3.CitySearchState get state => (super.noSuchMethod(
         Invocation.getter(#state),
-        returnValue: _FakeCitySearchState_0(
+        returnValue: _FakeCitySearchState_1(
           this,
           Invocation.getter(#state),
         ),
-      ) as _i2.CitySearchState);
+      ) as _i3.CitySearchState);
 
   @override
-  set state(_i2.CitySearchState? value) => super.noSuchMethod(
+  set state(_i3.CitySearchState? value) => super.noSuchMethod(
         Invocation.setter(
           #state,
           value,
@@ -84,19 +82,19 @@ class MockCitySearchViewModel extends _i1.Mock
       );
 
   @override
-  _i2.CitySearchState get debugState => (super.noSuchMethod(
-        Invocation.getter(#debugState),
-        returnValue: _FakeCitySearchState_0(
-          this,
-          Invocation.getter(#debugState),
+  _i3.CitySearchState build() => (super.noSuchMethod(
+        Invocation.method(
+          #build,
+          [],
         ),
-      ) as _i2.CitySearchState);
-
-  @override
-  bool get hasListeners => (super.noSuchMethod(
-        Invocation.getter(#hasListeners),
-        returnValue: false,
-      ) as bool);
+        returnValue: _FakeCitySearchState_1(
+          this,
+          Invocation.method(
+            #build,
+            [],
+          ),
+        ),
+      ) as _i3.CitySearchState);
 
   @override
   void updateCityName(String? cityName) => super.noSuchMethod(
@@ -119,40 +117,17 @@ class MockCitySearchViewModel extends _i1.Mock
 
   @override
   bool updateShouldNotify(
-    _i2.CitySearchState? old,
-    _i2.CitySearchState? current,
+    _i3.CitySearchState? previous,
+    _i3.CitySearchState? next,
   ) =>
       (super.noSuchMethod(
         Invocation.method(
           #updateShouldNotify,
           [
-            old,
-            current,
+            previous,
+            next,
           ],
         ),
         returnValue: false,
       ) as bool);
-
-  @override
-  _i4.RemoveListener addListener(
-    _i6.Listener<_i2.CitySearchState>? listener, {
-    bool? fireImmediately = true,
-  }) =>
-      (super.noSuchMethod(
-        Invocation.method(
-          #addListener,
-          [listener],
-          {#fireImmediately: fireImmediately},
-        ),
-        returnValue: () {},
-      ) as _i4.RemoveListener);
-
-  @override
-  void dispose() => super.noSuchMethod(
-        Invocation.method(
-          #dispose,
-          [],
-        ),
-        returnValueForMissingStub: null,
-      );
 }


### PR DESCRIPTION
### Overview
This pull request introduces the `CitySearchViewModel` for managing city search-related business logic and the corresponding unit tests to ensure its functionality.

### Details
#### ViewModel
- **CitySearchViewModel**: Manages the state for city search functionality.
  - Handles user input for city names.
  - Fetches weather information for the given city.
  - Manages loading state and error messages.

#### Providers
- **citySearchViewModelProvider**: A `NotifierProvider` that provides the `CitySearchViewModel` instance.

#### Tests
- **Unit Tests**: Added unit tests to verify the functionality of the `CitySearchViewModel`.
  - Test for updating the city name.
  - Test for fetching weather data successfully.
  - Test for handling errors during the fetch.
  - Test for handling empty city name input.

### Key Changes
- **ViewModel**: Implemented in `lib/view_model/city_search_view_model.dart`.
- **Providers**: Defined in `lib/view_model/providers/city_search_view_model_provider.dart`.
- **Mocks**: Added mock classes in `test/mocks/mock_city_search_view_model.mocks.dart`.
- **Tests**: Unit tests added in `test/view_model/city_search_view_model_test.dart`.

### Testing Details
- **Update City Name Test**: Verified that the city name is correctly updated in the state.
- **Fetch Weather Success Test**: Confirmed that the state is updated correctly when weather data is fetched successfully.
- **Fetch Weather Error Test**: Ensured proper error handling and state updates when fetching weather data fails.
- **Empty City Name Error Test**: Verified that the correct error message is set when the city name is empty.

Please review and merge these changes to incorporate the new ViewModel and unit tests into the project.
