### PR TITLE
Add Missing Generated Weather API Client File

### DIFF
--- a/lib/services/weather_api_client.g.dart
+++ b/lib/services/weather_api_client.g.dart
@@ -1,0 +1,89 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'weather_api_client.dart';
+
+// **************************************************************************
+// RetrofitGenerator
+// **************************************************************************
+
+// ignore_for_file: unnecessary_brace_in_string_interps,no_leading_underscores_for_local_identifiers,unused_element
+
+class _WeatherApiClient implements WeatherApiClient {
+  _WeatherApiClient(
+    this._dio, {
+    this.baseUrl,
+  }) {
+    baseUrl ??= 'https://api.openweathermap.org/data/2.5/';
+  }
+
+  final Dio _dio;
+
+  String? baseUrl;
+
+  @override
+  Future<WeatherResponse> fetchWeather(
+    String cityName,
+    String apiKey,
+    String lang,
+    String units,
+  ) async {
+    final _extra = <String, dynamic>{};
+    final queryParameters = <String, dynamic>{
+      r'q': cityName,
+      r'appId': apiKey,
+      r'lang': lang,
+      r'units': units,
+    };
+    final _headers = <String, dynamic>{};
+    const Map<String, dynamic>? _data = null;
+    final _result = await _dio
+        .fetch<Map<String, dynamic>>(_setStreamType<WeatherResponse>(Options(
+      method: 'GET',
+      headers: _headers,
+      extra: _extra,
+    )
+            .compose(
+              _dio.options,
+              'forecast',
+              queryParameters: queryParameters,
+              data: _data,
+            )
+            .copyWith(
+                baseUrl: _combineBaseUrls(
+              _dio.options.baseUrl,
+              baseUrl,
+            ))));
+    final _value = WeatherResponse.fromJson(_result.data!);
+    return _value;
+  }
+
+  RequestOptions _setStreamType<T>(RequestOptions requestOptions) {
+    if (T != dynamic &&
+        !(requestOptions.responseType == ResponseType.bytes ||
+            requestOptions.responseType == ResponseType.stream)) {
+      if (T == String) {
+        requestOptions.responseType = ResponseType.plain;
+      } else {
+        requestOptions.responseType = ResponseType.json;
+      }
+    }
+    return requestOptions;
+  }
+
+  String _combineBaseUrls(
+    String dioBaseUrl,
+    String? baseUrl,
+  ) {
+    if (baseUrl == null || baseUrl.trim().isEmpty) {
+      return dioBaseUrl;
+    }
+
+    final url = Uri.parse(baseUrl);
+
+    if (url.isAbsolute) {
+      return url.toString();
+    }
+
+    return Uri.parse(dioBaseUrl).resolveUri(url).toString();
+  }
+}


### PR DESCRIPTION
This PR adds the missing generated file for the `WeatherApiClient` which was inadvertently left out in the previous commit. This file is crucial for the Retrofit API client functionality and is necessary for fetching weather data.

Changes:
- Added the missing generated file `weather_api_client.g.dart`.

This update ensures that the weather API client can function correctly with the updated weather model.

Please review and merge this PR to complete the changes related to the weather model update.
