### PR TITLE
Add StubWeatherDataSource and Its Unit Tests

### DIFF
--- a/lib/services/stub_weather_data_source.dart
+++ b/lib/services/stub_weather_data_source.dart
@@ -1,0 +1,30 @@
+import 'package:weather_app/core/network/response/weather_list.dart';
+import 'package:weather_app/core/network/response/weather_response.dart';
+import 'package:weather_app/models/weather_description.dart';
+import 'package:weather_app/models/weather_main.dart';
+import 'package:weather_app/models/weather_wind.dart';
+import 'package:weather_app/services/weather_api_client.dart';
+
+// StubWeatherDataSourceクラスは、WeatherApiClientインターフェースのスタブ実装です。
+// テスト目的で使用され、固定されたデータを返します。
+class StubWeatherDataSource implements WeatherApiClient {
+  @override
+  // fetchWeatherメソッドは、指定された都市名、APIキー、言語、単位を使用して
+  // 天気情報を取得するメソッドです。このスタブ実装では固定されたデータを返します。
+  Future<WeatherResponse> fetchWeather(
+      String cityName, String apiKey, String lang, String units) async {
+    // 無効な都市名が指定された場合、例外をスローします。
+    if (cityName == 'InvalidCity') {
+      throw Exception('Failed to fetch weather data');
+    }
+
+    // 有効な都市名が指定された場合、固定された天気データを返します。
+    return WeatherResponse(list: [
+      WeatherList(
+        main: WeatherMain(temp: 20.0, humidity: 70), // 気温と湿度
+        weather: [WeatherDescription(description: 'Sunny')], // 天気の説明
+        wind: WeatherWind(speed: 5.0), // 風速
+      )
+    ]);
+  }
+}

--- a/test/services/stub_weather_data_source_test.dart
+++ b/test/services/stub_weather_data_source_test.dart
@@ -1,0 +1,54 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:weather_app/core/network/response/result.dart';
+import 'package:weather_app/models/weather_model.dart';
+import 'package:weather_app/repositories/weather_repository_provider.dart';
+import 'package:weather_app/services/stub_weather_data_source.dart';
+import 'package:weather_app/services/weather_api_client_provider.dart';
+
+void main() {
+  group('WeatherRepositoryImpl with StubWeatherDataSource', () {
+    late ProviderContainer container;
+
+    // 各テスト前に実行されるセットアップ処理
+    setUp(() {
+      // ProviderContainerを作成し、weatherApiClientProviderをStubWeatherDataSourceでオーバーライド
+      container = ProviderContainer(overrides: [
+        weatherApiClientProvider.overrideWithValue(StubWeatherDataSource())
+      ]);
+    });
+
+    // 正常に天気データが取得できるかのテスト
+    test('成功時にWeatherModelのリストを返す', () async {
+      // weatherRepositoryProviderからリポジトリを取得
+      final repository = container.read(weatherRepositoryProvider);
+
+      // 東京の天気データを取得
+      final result = await repository.getWeather('Tokyo');
+
+      // 成功かどうかをチェック
+      expect(result, isA<Success<List<WeatherModel>>>());
+
+      // 成功時の結果を取得
+      final weather = (result as Success<List<WeatherModel>>).value;
+
+      // データが期待通りか確認
+      expect(weather, isA<List<WeatherModel>>());
+      expect(weather.first.cityName, 'Tokyo');
+      expect(weather.first.temperature, 20.0);
+      expect(weather.first.description, 'Sunny');
+      expect(weather.first.windSpeed, 5.0);
+      expect(weather.first.humidity, 70);
+    });
+
+    // API呼び出しが失敗した場合に例外がスローされるかのテスト
+    test('API呼び出し失敗時に例外をスローする', () {
+      // 必要に応じてStubWeatherDataSourceに例外をスローするロジックを追加してテストする
+      expect(
+          () async => await container
+              .read(weatherRepositoryProvider)
+              .getWeather('InvalidCity'),
+          throwsException);
+    });
+  });
+}

--- a/test/services/stub_weather_data_source_test.dart
+++ b/test/services/stub_weather_data_source_test.dart
@@ -1,7 +1,7 @@
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:weather_app/core/network/response/result.dart';
-import 'package:weather_app/models/weather_model.dart';
+import 'package:weather_app/core/network/response/weather_list.dart';
 import 'package:weather_app/repositories/weather_repository_provider.dart';
 import 'package:weather_app/services/stub_weather_data_source.dart';
 import 'package:weather_app/services/weather_api_client_provider.dart';
@@ -19,7 +19,7 @@ void main() {
     });
 
     // 正常に天気データが取得できるかのテスト
-    test('成功時にWeatherModelのリストを返す', () async {
+    test('成功時にWeatherListのリストを返す', () async {
       // weatherRepositoryProviderからリポジトリを取得
       final repository = container.read(weatherRepositoryProvider);
 
@@ -27,28 +27,29 @@ void main() {
       final result = await repository.getWeather('Tokyo');
 
       // 成功かどうかをチェック
-      expect(result, isA<Success<List<WeatherModel>>>());
+      expect(result, isA<Success<List<WeatherList>>>());
 
       // 成功時の結果を取得
-      final weather = (result as Success<List<WeatherModel>>).value;
+      final weatherList = (result as Success<List<WeatherList>>).value;
 
       // データが期待通りか確認
-      expect(weather, isA<List<WeatherModel>>());
-      expect(weather.first.cityName, 'Tokyo');
-      expect(weather.first.temperature, 20.0);
-      expect(weather.first.description, 'Sunny');
-      expect(weather.first.windSpeed, 5.0);
-      expect(weather.first.humidity, 70);
+      expect(weatherList, isA<List<WeatherList>>());
+      expect(weatherList.first.main.temp, 20.0);
+      expect(weatherList.first.weather.first.description, 'Sunny');
+      expect(weatherList.first.wind.speed, 5.0);
+      expect(weatherList.first.main.humidity, 70);
     });
 
     // API呼び出しが失敗した場合に例外がスローされるかのテスト
-    test('API呼び出し失敗時に例外をスローする', () {
-      // 必要に応じてStubWeatherDataSourceに例外をスローするロジックを追加してテストする
-      expect(
-          () async => await container
-              .read(weatherRepositoryProvider)
-              .getWeather('InvalidCity'),
-          throwsException);
+    test('API呼び出し失敗時にResult.failureを返す', () async {
+      // weatherRepositoryProviderからリポジトリを取得
+      final repository = container.read(weatherRepositoryProvider);
+
+      // 無効な都市名の天気データを取得
+      final result = await repository.getWeather('InvalidCity');
+
+      // 失敗かどうかをチェック
+      expect(result, isA<Failure<List<WeatherList>>>());
     });
   });
 }


### PR DESCRIPTION
This PR introduces the `StubWeatherDataSource` class and its corresponding unit tests to the project. The `StubWeatherDataSource` provides a stub implementation of the `WeatherApiClient` interface, returning fixed data for testing purposes.

Changes:
- Added `lib/services/stub_weather_data_source.dart`: Provides a stub implementation of the `WeatherApiClient` for testing.
- Added `test/services/stub_weather_data_source_test.dart`: Contains unit tests for the `StubWeatherDataSource`.

The `StubWeatherDataSource` is useful for testing scenarios without making actual network calls, ensuring consistent and predictable test results.

Please review and merge this PR to include the stub data source and its tests in the project.
