### PR TITLE
Add CityWeatherProvider for Fetching Weather Data

### DIFF
--- a/lib/view_model/providers/city_weather_provider.dart
+++ b/lib/view_model/providers/city_weather_provider.dart
@@ -1,0 +1,26 @@
+import 'package:dio/dio.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:weather_app/core/network/response/result.dart';
+import 'package:weather_app/core/network/response/weather_list.dart';
+import 'package:weather_app/repositories/weather_repository_provider.dart';
+
+// FutureProviderを定義して特定の都市の天気情報を取得する
+final cityWeatherProvider =
+    FutureProvider.family<Result<List<WeatherList>>, String>(
+        (ref, cityName) async {
+  // weatherRepositoryProviderからWeatherRepositoryのインスタンスを取得
+  final weatherRepository = ref.read(weatherRepositoryProvider);
+
+  try {
+    // 指定された都市の天気情報を非同期に取得し、結果をresultに格納
+    final result = weatherRepository.getWeather(cityName);
+    // 取得した天気情報の結果を返す
+    return result;
+  } catch (e) {
+    // エラーをキャッチし、Result.failureを返す
+    return Result.failure(DioException(
+      requestOptions: RequestOptions(path: ''),
+      error: e,
+    ));
+  }
+});


### PR DESCRIPTION
This PR introduces the `cityWeatherProvider` to the project, enabling the fetching of weather data for a specified city using Riverpod's `FutureProvider.family`.

Changes:
- Added `lib/providers/city_weather_provider.dart`: Defines the `cityWeatherProvider` for fetching weather data for a specific city.

The `cityWeatherProvider` leverages the `weatherRepositoryProvider` to fetch weather data asynchronously and handle any errors that may occur during the process, encapsulating the results in a `Result` type.

Please review and merge this PR to include the new provider for fetching city-specific weather data in the project.