### PR TITLE
Setup Routing and Main Entry Point for Weather App

### DIFF
--- a/lib/components/city_search_button.dart
+++ b/lib/components/city_search_button.dart
@@ -1,9 +1,13 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:go_router/go_router.dart';
 import 'package:weather_app/view_model/providers/city_search_view_model_provider.dart';
 
+// CitySearchButtonウィジェットは、都市名の検索ボタンを提供します。
 class CitySearchButton extends ConsumerWidget {
-  const CitySearchButton({super.key});
+  final TextEditingController controller;
+
+  const CitySearchButton({super.key, required this.controller});
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
@@ -16,20 +20,32 @@ class CitySearchButton extends ConsumerWidget {
 
     return ElevatedButton(
       // ボタンが押されたときの動作。ローディング中は無効化
-      onPressed: state.isLoading ? null : () => viewModel.fetchWeather(),
+      onPressed: state.isLoading
+          ? null
+          : () async {
+              final cityName = controller.text;
+              if (cityName.isNotEmpty) {
+                // 天気情報を取得し、成功した場合は結果画面に遷移
+                viewModel
+                    .fetchWeather()
+                    .then((_) => context.go('/result/$cityName'));
+              }
+            },
       // ボタンのスタイルを定義。テーマから色を取得し、最小サイズを設定
       style: ElevatedButton.styleFrom(
-        foregroundColor: Colors.white,
-        backgroundColor: theme.primaryColor,
-        minimumSize: const Size.fromHeight(50),
+        foregroundColor: Colors.white, // フォアグラウンドカラーを白に設定
+        backgroundColor: theme.primaryColor, // 背景色をテーマのプライマリカラーに設定
+        minimumSize: const Size.fromHeight(50), // ボタンの最小サイズを高さ50に設定
       ),
       // ローディング状態に応じて子ウィジェットを切り替え
       child: state.isLoading
           ? const CircularProgressIndicator(
               valueColor: AlwaysStoppedAnimation<Color>(Colors.white),
-            )
-          : const Text('Search',
-              style: TextStyle(fontWeight: FontWeight.bold, fontSize: 20)),
+            ) // ローディング中はCircularProgressIndicatorを表示
+          : const Text(
+              'Search',
+              style: TextStyle(fontWeight: FontWeight.bold, fontSize: 20),
+            ), // 通常時は"Search"テキストを表示
     );
   }
 }

--- a/lib/components/city_search_input.dart
+++ b/lib/components/city_search_input.dart
@@ -4,7 +4,8 @@ import 'package:weather_app/view_model/providers/city_search_view_model_provider
 
 // CitySearchInputウィジェットは、都市名の検索入力フィールドを提供します。
 class CitySearchInput extends ConsumerWidget {
-  const CitySearchInput({super.key});
+  final TextEditingController controller;
+  const CitySearchInput({required this.controller, super.key});
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
@@ -15,6 +16,7 @@ class CitySearchInput extends ConsumerWidget {
 
     // テキスト入力フィールドを構築します。
     return TextFormField(
+      controller: controller,
       // 入力フィールドのデコレーションを設定します。
       decoration: InputDecoration(
         filled: true, // 背景を塗りつぶします。

--- a/lib/core/routing/app_router.dart
+++ b/lib/core/routing/app_router.dart
@@ -1,0 +1,26 @@
+import 'package:go_router/go_router.dart';
+import 'package:weather_app/view/screens/city_search_screen.dart';
+import 'package:weather_app/view/screens/weather_result_screen.dart';
+
+class AppRouter {
+  // アプリケーションのルーターを定義
+  static final router = GoRouter(routes: [
+    // ルート設定: ルートパス '/' に対応する画面を CitySearchScreen に設定
+    GoRoute(
+      path: '/',
+      builder: (context, state) => CitySearchScreen(),
+    ),
+    // ルート設定: ルートパス '/result/:city' に対応する画面を WeatherResultScreen に設定
+    GoRoute(
+      path: '/result/:city',
+      builder: (context, state) {
+        // パスパラメータから都市名を取得する
+        final cityName = state.pathParameters['city'];
+        // 取得した都市名を WeatherResultScreen に渡して画面を表示
+        return WeatherResultScreen(
+          cityName: cityName!,
+        );
+      },
+    ),
+  ]);
+}

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,69 +1,30 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:weather_app/core/routing/app_router.dart';
 
+// アプリケーションのエントリーポイント
 void main() {
-  runApp(const MyApp());
+  runApp(const ProviderScope(child: MyApp()));
 }
 
+// MyAppウィジェットの定義。アプリのルートウィジェットです。
 class MyApp extends StatelessWidget {
   const MyApp({super.key});
 
   @override
   Widget build(BuildContext context) {
-    return MaterialApp(
-      title: 'Flutter Demo',
+    return MaterialApp.router(
+      // アプリのタイトル
+      title: 'Weather App',
+      // アプリのテーマ設定
       theme: ThemeData(
+        // カラースキームの設定。深い紫色を基調にしています。
         colorScheme: ColorScheme.fromSeed(seedColor: Colors.deepPurple),
+        // Material 3の使用を有効化
         useMaterial3: true,
       ),
-      home: const MyHomePage(title: 'Flutter Demo Home Page'),
-    );
-  }
-}
-
-class MyHomePage extends StatefulWidget {
-  const MyHomePage({super.key, required this.title});
-
-  final String title;
-
-  @override
-  State<MyHomePage> createState() => _MyHomePageState();
-}
-
-class _MyHomePageState extends State<MyHomePage> {
-  int _counter = 0;
-
-  void _incrementCounter() {
-    setState(() {
-      _counter++;
-    });
-  }
-
-  @override
-  Widget build(BuildContext context) {
-    return Scaffold(
-      appBar: AppBar(
-        backgroundColor: Theme.of(context).colorScheme.inversePrimary,
-        title: Text(widget.title),
-      ),
-      body: Center(
-        child: Column(
-          mainAxisAlignment: MainAxisAlignment.center,
-          children: <Widget>[
-            const Text(
-              'You have pushed the button this many times:',
-            ),
-            Text(
-              '$_counter',
-              style: Theme.of(context).textTheme.headlineMedium,
-            ),
-          ],
-        ),
-      ),
-      floatingActionButton: FloatingActionButton(
-        onPressed: _incrementCounter,
-        tooltip: 'Increment',
-        child: const Icon(Icons.add),
-      ),
+      // ルーティングの設定
+      routerConfig: AppRouter.router,
     );
   }
 }

--- a/test/components/city_search_button_test.dart
+++ b/test/components/city_search_button_test.dart
@@ -12,6 +12,7 @@ void main() {
   group('CitySearchButtonのテスト', () {
     late CustomMockCitySearchViewModel mockViewModel;
     late ProviderContainer container;
+    late TextEditingController controller;
 
     setUp(() {
       // モックのViewModelを初期化
@@ -20,6 +21,8 @@ void main() {
       container = ProviderContainer(overrides: [
         customMockCitySearchViewModelProvider.overrideWithValue(mockViewModel),
       ]);
+      // コントローラの初期化
+      controller = TextEditingController();
     });
 
     testWidgets('CitySearchButtonが表示される', (WidgetTester tester) async {
@@ -29,9 +32,9 @@ void main() {
       // テスト対象のウィジェットを構築
       await tester.pumpWidget(UncontrolledProviderScope(
         container: container,
-        child: const MaterialApp(
+        child: MaterialApp(
           home: Scaffold(
-            body: CitySearchButton(),
+            body: CitySearchButton(controller: controller),
           ),
         ),
       ));
@@ -48,9 +51,9 @@ void main() {
       // テスト対象のウィジェットを構築
       await tester.pumpWidget(UncontrolledProviderScope(
         container: container,
-        child: const MaterialApp(
+        child: MaterialApp(
           home: Scaffold(
-            body: CitySearchButton(),
+            body: CitySearchButton(controller: controller),
           ),
         ),
       ));
@@ -68,9 +71,9 @@ void main() {
       // テスト対象のウィジェットを構築
       await tester.pumpWidget(UncontrolledProviderScope(
         container: container,
-        child: const MaterialApp(
+        child: MaterialApp(
           home: Scaffold(
-            body: CitySearchButton(),
+            body: CitySearchButton(controller: controller),
           ),
         ),
       ));

--- a/test/components/city_search_input_test.dart
+++ b/test/components/city_search_input_test.dart
@@ -6,12 +6,16 @@ import 'package:weather_app/components/city_search_input.dart';
 void main() {
   group('CitySearchInput Tests', () {
     testWidgets('CitySearchInput is displayed', (WidgetTester tester) async {
+      final controller = TextEditingController();
+
       // テストウィジェットを構築
       await tester.pumpWidget(
-        const ProviderScope(
+        ProviderScope(
           child: MaterialApp(
             home: Scaffold(
-              body: CitySearchInput(),
+              body: CitySearchInput(
+                controller: controller,
+              ),
             ),
           ),
         ),
@@ -25,12 +29,16 @@ void main() {
 
     testWidgets('CitySearchInput accepts text input',
         (WidgetTester tester) async {
+      final controller = TextEditingController();
+
       // テストウィジェットを構築
       await tester.pumpWidget(
-        const ProviderScope(
+        ProviderScope(
           child: MaterialApp(
             home: Scaffold(
-              body: CitySearchInput(),
+              body: CitySearchInput(
+                controller: controller,
+              ),
             ),
           ),
         ),

--- a/test/widget_test.dart
+++ b/test/widget_test.dart
@@ -1,23 +1,15 @@
-import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:weather_app/main.dart';
+import 'package:weather_app/view/screens/city_search_screen.dart';
 
 void main() {
-  testWidgets('Counter increments smoke test', (WidgetTester tester) async {
+  testWidgets('CitySearchScreen displays correctly',
+      (WidgetTester tester) async {
     // テストウィジェットをProviderScopeでラップ
     await tester.pumpWidget(const ProviderScope(child: MyApp()));
 
-    // Verify that our counter starts at 0.
-    expect(find.text('0'), findsOneWidget);
-    expect(find.text('1'), findsNothing);
-
-    // Tap the '+' icon and trigger a frame.
-    await tester.tap(find.byIcon(Icons.add));
-    await tester.pump();
-
-    // Verify that our counter has incremented.
-    expect(find.text('0'), findsNothing);
-    expect(find.text('1'), findsOneWidget);
+    // Verify that CitySearchScreen is displayed
+    expect(find.byType(CitySearchScreen), findsOneWidget);
   });
 }

--- a/test/widget_test.dart
+++ b/test/widget_test.dart
@@ -1,19 +1,12 @@
-// This is a basic Flutter widget test.
-//
-// To perform an interaction with a widget in your test, use the WidgetTester
-// utility in the flutter_test package. For example, you can send tap and scroll
-// gestures. You can also use WidgetTester to find child widgets in the widget
-// tree, read text, and verify that the values of widget properties are correct.
-
 import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
-
 import 'package:weather_app/main.dart';
 
 void main() {
   testWidgets('Counter increments smoke test', (WidgetTester tester) async {
-    // Build our app and trigger a frame.
-    await tester.pumpWidget(const MyApp());
+    // テストウィジェットをProviderScopeでラップ
+    await tester.pumpWidget(const ProviderScope(child: MyApp()));
 
     // Verify that our counter starts at 0.
     expect(find.text('0'), findsOneWidget);


### PR DESCRIPTION
This PR sets up the routing and main entry point for the Weather App. The changes introduce the basic structure needed to navigate between different screens within the application.

Changes:
- **lib/main.dart**: Defines the main entry point of the application, setting up the `ProviderScope` and `MaterialApp.router` for routing.
- **lib/core/routing/app_router.dart**: Configures the routing using `GoRouter`, defining routes for the city search screen and weather result screen.

Key Features:
- **Routing**: Implements `GoRouter` to manage app navigation.
- **City Search Screen**: Default screen for searching city weather.
- **Weather Result Screen**: Displays weather results for the selected city.

Please review and merge this PR to integrate the routing setup and main entry point into the project.
