### PR TITLE
Add City Search and Weather Result Screens

### DIFF
--- a/lib/view/screens/city_search_screen.dart
+++ b/lib/view/screens/city_search_screen.dart
@@ -1,0 +1,38 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_keyboard_visibility/flutter_keyboard_visibility.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:weather_app/components/city_search_button.dart';
+import 'package:weather_app/components/city_search_input.dart';
+
+// CitySearchScreenは、ユーザーが都市名を入力して天気情報を検索する画面です。
+class CitySearchScreen extends ConsumerWidget {
+  final TextEditingController controller = TextEditingController();
+
+  CitySearchScreen({super.key});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    return KeyboardDismissOnTap(
+        child: Scaffold(
+      // キーボードが表示された時にタップでキーボードを閉じる設定
+      body: Center(
+          child: SingleChildScrollView(
+        reverse: true,
+        child: Column(
+          mainAxisAlignment: MainAxisAlignment.center,
+          children: [
+            const SizedBox(height: 20),
+            Padding(
+              padding: const EdgeInsets.symmetric(horizontal: 40.0),
+              // 都市名入力用のウィジェット
+              child: CitySearchInput(controller: controller),
+            ),
+            const SizedBox(height: 20),
+            // 検索ボタンウィジェット
+            CitySearchButton(controller: controller),
+          ],
+        ),
+      )),
+    ));
+  }
+}

--- a/lib/view/screens/weather_result_screen.dart
+++ b/lib/view/screens/weather_result_screen.dart
@@ -1,0 +1,52 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:weather_app/view_model/providers/city_weather_provider.dart';
+
+// WeatherResultScreenは、指定された都市の天気情報を表示する画面です。
+class WeatherResultScreen extends ConsumerWidget {
+  final String cityName;
+
+  const WeatherResultScreen({super.key, required this.cityName});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    // FutureProviderを利用して天気情報を取得
+    final weatherResult = ref.watch(cityWeatherProvider(cityName));
+
+    return Scaffold(
+      body: Center(
+        child: weatherResult.when(
+          // データ取得成功時の処理
+          data: (data) {
+            return data.when(success: (weatherList) {
+              if (weatherList.isEmpty) {
+                return const Text('No weather data available');
+              }
+              final weather = weatherList.first;
+              return Column(
+                mainAxisAlignment: MainAxisAlignment.center,
+                children: [
+                  Text('都市名: $cityName'), // 都市名を表示
+                  Text(
+                      '気温: ${weather.main.temp.toStringAsFixed(1)}°C'), // 気温を表示
+                  Text('湿度: ${weather.main.humidity}%'), // 湿度を表示
+                  Text(
+                      '風速: ${weather.wind.speed.toStringAsFixed(1)}m/s'), // 風速を表示
+                  Text('天気: ${weather.weather.first.description}'), // 天気の説明を表示
+                ],
+              );
+            }, failure: (error) {
+              return Text('Error: ${error.message}'); // データ取得失敗時のエラーメッセージ
+            });
+          },
+          // エラー発生時の処理
+          error: (e, s) {
+            return Text('Error: $e'); // 例外発生時のエラーメッセージ
+          },
+          // ローディング中の処理
+          loading: () => const CircularProgressIndicator(), // ローディングインジケーターを表示
+        ),
+      ),
+    );
+  }
+}


### PR DESCRIPTION
This PR introduces two new screens for the Weather App: the City Search screen and the Weather Result screen. These additions allow users to input a city name and view the corresponding weather information.

Changes:
- **lib/view/screens/city_search_screen.dart**: 
  - `CitySearchScreen` allows users to enter a city name and search for weather information.
  - Includes a text input field and a search button.
  - Utilizes `KeyboardDismissOnTap` to close the keyboard when tapping outside the input field.

- **lib/view/screens/weather_result_screen.dart**: 
  - `WeatherResultScreen` displays the weather information for the specified city.
  - Uses the `cityWeatherProvider` to fetch and display weather data, including temperature, humidity, wind speed, and weather description.

Key Features:
- **City Search Input**: Users can input a city name.
- **Weather Display**: Displays weather information including temperature, humidity, wind speed, and description.
- **Error Handling**: Shows error messages when data fetching fails.
- **Loading State**: Displays a loading indicator while fetching data.

Please review and merge this PR to integrate the new city search and weather result screens into the project.
