### PR TITLE
Add ApiError Class for Handling API Errors

### DIFF
--- a/lib/core/network/api_error.dart
+++ b/lib/core/network/api_error.dart
@@ -1,0 +1,24 @@
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+part 'api_error.freezed.dart';
+
+// APIエラーの種類を定義する列挙型
+enum ApiErrorType {
+  timeout, // タイムアウト
+  cancel, // リクエストキャンセル
+  badRequest, // 不正なリクエスト
+  unauthorized, // 認証エラー
+  notFound, // リソースが見つからない
+  tooManyRequests, // リクエストが多すぎる
+  internalServerError, // サーバー内部エラー
+  unknown, // 不明なエラー
+}
+
+// APIエラーを表現するクラス
+@freezed
+class ApiError with _$ApiError {
+  const factory ApiError({
+    required ApiErrorType type, // エラーの種類
+    required String message, // エラーメッセージ
+  }) = _ApiError;
+}

--- a/lib/core/network/api_error.freezed.dart
+++ b/lib/core/network/api_error.freezed.dart
@@ -1,0 +1,150 @@
+// coverage:ignore-file
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
+
+part of 'api_error.dart';
+
+// **************************************************************************
+// FreezedGenerator
+// **************************************************************************
+
+T _$identity<T>(T value) => value;
+
+final _privateConstructorUsedError = UnsupportedError(
+    'It seems like you constructed your class using `MyClass._()`. This constructor is only meant to be used by freezed and you are not supposed to need it nor use it.\nPlease check the documentation here for more information: https://github.com/rrousselGit/freezed#adding-getters-and-methods-to-our-models');
+
+/// @nodoc
+mixin _$ApiError {
+  ApiErrorType get type => throw _privateConstructorUsedError; // エラーの種類
+  String get message => throw _privateConstructorUsedError;
+
+  @JsonKey(ignore: true)
+  $ApiErrorCopyWith<ApiError> get copyWith =>
+      throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+abstract class $ApiErrorCopyWith<$Res> {
+  factory $ApiErrorCopyWith(ApiError value, $Res Function(ApiError) then) =
+      _$ApiErrorCopyWithImpl<$Res, ApiError>;
+  @useResult
+  $Res call({ApiErrorType type, String message});
+}
+
+/// @nodoc
+class _$ApiErrorCopyWithImpl<$Res, $Val extends ApiError>
+    implements $ApiErrorCopyWith<$Res> {
+  _$ApiErrorCopyWithImpl(this._value, this._then);
+
+  // ignore: unused_field
+  final $Val _value;
+  // ignore: unused_field
+  final $Res Function($Val) _then;
+
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? type = null,
+    Object? message = null,
+  }) {
+    return _then(_value.copyWith(
+      type: null == type
+          ? _value.type
+          : type // ignore: cast_nullable_to_non_nullable
+              as ApiErrorType,
+      message: null == message
+          ? _value.message
+          : message // ignore: cast_nullable_to_non_nullable
+              as String,
+    ) as $Val);
+  }
+}
+
+/// @nodoc
+abstract class _$$ApiErrorImplCopyWith<$Res>
+    implements $ApiErrorCopyWith<$Res> {
+  factory _$$ApiErrorImplCopyWith(
+          _$ApiErrorImpl value, $Res Function(_$ApiErrorImpl) then) =
+      __$$ApiErrorImplCopyWithImpl<$Res>;
+  @override
+  @useResult
+  $Res call({ApiErrorType type, String message});
+}
+
+/// @nodoc
+class __$$ApiErrorImplCopyWithImpl<$Res>
+    extends _$ApiErrorCopyWithImpl<$Res, _$ApiErrorImpl>
+    implements _$$ApiErrorImplCopyWith<$Res> {
+  __$$ApiErrorImplCopyWithImpl(
+      _$ApiErrorImpl _value, $Res Function(_$ApiErrorImpl) _then)
+      : super(_value, _then);
+
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? type = null,
+    Object? message = null,
+  }) {
+    return _then(_$ApiErrorImpl(
+      type: null == type
+          ? _value.type
+          : type // ignore: cast_nullable_to_non_nullable
+              as ApiErrorType,
+      message: null == message
+          ? _value.message
+          : message // ignore: cast_nullable_to_non_nullable
+              as String,
+    ));
+  }
+}
+
+/// @nodoc
+
+class _$ApiErrorImpl implements _ApiError {
+  const _$ApiErrorImpl({required this.type, required this.message});
+
+  @override
+  final ApiErrorType type;
+// エラーの種類
+  @override
+  final String message;
+
+  @override
+  String toString() {
+    return 'ApiError(type: $type, message: $message)';
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _$ApiErrorImpl &&
+            (identical(other.type, type) || other.type == type) &&
+            (identical(other.message, message) || other.message == message));
+  }
+
+  @override
+  int get hashCode => Object.hash(runtimeType, type, message);
+
+  @JsonKey(ignore: true)
+  @override
+  @pragma('vm:prefer-inline')
+  _$$ApiErrorImplCopyWith<_$ApiErrorImpl> get copyWith =>
+      __$$ApiErrorImplCopyWithImpl<_$ApiErrorImpl>(this, _$identity);
+}
+
+abstract class _ApiError implements ApiError {
+  const factory _ApiError(
+      {required final ApiErrorType type,
+      required final String message}) = _$ApiErrorImpl;
+
+  @override
+  ApiErrorType get type;
+  @override // エラーの種類
+  String get message;
+  @override
+  @JsonKey(ignore: true)
+  _$$ApiErrorImplCopyWith<_$ApiErrorImpl> get copyWith =>
+      throw _privateConstructorUsedError;
+}


### PR DESCRIPTION
This PR introduces the `ApiError` class to better handle and represent different types of API errors in the Weather App. Additionally, it includes the generated code for `ApiError` using Freezed.

### Changes:
- **New Class**: `ApiError`
  - **Enum**: `ApiErrorType`
    - `timeout`: Represents a timeout error.
    - `cancel`: Represents a request cancellation error.
    - `badRequest`: Represents a bad request error.
    - `unauthorized`: Represents an authentication error.
    - `notFound`: Represents a resource not found error.
    - `tooManyRequests`: Represents a too many requests error.
    - `internalServerError`: Represents an internal server error.
    - `unknown`: Represents an unknown error.
  - **Fields**:
    - `type`: The type of the error (using `ApiErrorType`).
    - `message`: The error message.
- **Generated Code**: `api_error.freezed.dart`
  - This file contains the generated code for the `ApiError` class, including copyWith methods, equality checks, and other utility methods.

This class will help in standardizing error handling across the app by categorizing errors into specific types and providing meaningful messages.

Please review the changes and merge this PR to add the new error handling mechanism.
