### PR TITLE
Add Dio Error Handling with DioErrorHandler Class

### DIFF
--- a/lib/core/network/dio_error_handler.dart
+++ b/lib/core/network/dio_error_handler.dart
@@ -1,0 +1,84 @@
+import 'package:dio/dio.dart';
+import 'package:weather_app/core/network/api_error.dart';
+
+// DioErrorHandlerクラスはDioExceptionを処理し、適切なApiErrorに変換します。
+class DioErrorHandler {
+  // DioExceptionを受け取り、対応するApiErrorを返すメソッド。
+  ApiError handle(DioException error) {
+    switch (error.type) {
+      // 接続タイムアウトエラーの処理
+      case DioExceptionType.connectionTimeout:
+        return const ApiError(
+          type: ApiErrorType.timeout,
+          message: '接続タイムアウトが発生しました。\nネットワークの状態を確認してください。',
+        );
+
+      // リクエスト送信タイムアウトエラーの処理
+      case DioExceptionType.sendTimeout:
+        return const ApiError(
+          type: ApiErrorType.timeout,
+          message: 'リクエスト送信タイムアウトが発生しました。\nネットワークの状態を確認してください。',
+        );
+
+      // レスポンス受信タイムアウトエラーの処理
+      case DioExceptionType.receiveTimeout:
+        return const ApiError(
+          type: ApiErrorType.timeout,
+          message: 'レスポンス受信タイムアウトが発生しました。\nネットワークの状態を確認してください。',
+        );
+
+      // 不正リクエストなどのサーバーからのエラーレスポンスの処理
+      case DioExceptionType.badResponse:
+        switch (error.response?.statusCode) {
+          case 400:
+            return const ApiError(
+              type: ApiErrorType.badRequest,
+              message: 'リクエストが不正です。\n必須パラメータが欠如しているか、フォーマットが不正です。',
+            );
+          case 401:
+            return const ApiError(
+              type: ApiErrorType.unauthorized,
+              message: '認証されていません。\nAPIトークンが提供されていないか、アクセス権がありません。',
+            );
+          case 404:
+            return const ApiError(
+              type: ApiErrorType.notFound,
+              message: 'データが見つかりませんでした。\nリクエストパラメータに誤りがあります。',
+            );
+          case 429:
+            return const ApiError(
+              type: ApiErrorType.tooManyRequests,
+              message: 'リクエストが多すぎます。\nしばらく待ってから再試行してください。',
+            );
+          case 500:
+          case 502:
+          case 503:
+          case 504:
+            return const ApiError(
+              type: ApiErrorType.internalServerError,
+              message: '内部サーバーエラーが発生しました。\nしばらくしてから再試行してください。',
+            );
+          default:
+            return const ApiError(
+              type: ApiErrorType.unknown,
+              message: '不明なエラーが発生しました。\n後でもう一度お試しください。',
+            );
+        }
+
+      // リクエストがキャンセルされた場合の処理
+      case DioExceptionType.cancel:
+        return const ApiError(
+          type: ApiErrorType.cancel,
+          message: 'リクエストがキャンセルされました。',
+        );
+
+      // その他の未知のエラータイプの処理
+      case DioExceptionType.unknown:
+      default:
+        return const ApiError(
+          type: ApiErrorType.unknown,
+          message: '不明なエラーが発生しました。\n後でもう一度お試しください。',
+        );
+    }
+  }
+}

--- a/lib/view_model/providers/dio_error_handler_provider.dart
+++ b/lib/view_model/providers/dio_error_handler_provider.dart
@@ -1,0 +1,7 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:weather_app/core/network/dio_error_handler.dart';
+
+// プロバイダー定義
+final dioErrorHandlerProvider = Provider<DioErrorHandler>((ref) {
+  return DioErrorHandler();
+});

--- a/test/core/network/dio_error_handler_test.dart
+++ b/test/core/network/dio_error_handler_test.dart
@@ -1,0 +1,154 @@
+import 'package:dio/dio.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:weather_app/core/network/api_error.dart';
+import 'package:weather_app/core/network/dio_error_handler.dart';
+
+void main() {
+  group('DioErrorHandlerのテスト', () {
+    final dioErrorHandler = DioErrorHandler();
+
+    test('接続タイムアウトエラーを処理する', () {
+      final dioError = DioException(
+        type: DioExceptionType.connectionTimeout,
+        requestOptions: RequestOptions(path: ''),
+      );
+
+      final apiError = dioErrorHandler.handle(dioError);
+
+      expect(apiError.type, ApiErrorType.timeout);
+      expect(apiError.message, '接続タイムアウトが発生しました。\nネットワークの状態を確認してください。');
+    });
+
+    test('送信タイムアウトエラーを処理する', () {
+      final dioError = DioException(
+        type: DioExceptionType.sendTimeout,
+        requestOptions: RequestOptions(path: ''),
+      );
+
+      final apiError = dioErrorHandler.handle(dioError);
+
+      expect(apiError.type, ApiErrorType.timeout);
+      expect(apiError.message, 'リクエスト送信タイムアウトが発生しました。\nネットワークの状態を確認してください。');
+    });
+
+    test('受信タイムアウトエラーを処理する', () {
+      final dioError = DioException(
+        type: DioExceptionType.receiveTimeout,
+        requestOptions: RequestOptions(path: ''),
+      );
+
+      final apiError = dioErrorHandler.handle(dioError);
+
+      expect(apiError.type, ApiErrorType.timeout);
+      expect(apiError.message, 'レスポンス受信タイムアウトが発生しました。\nネットワークの状態を確認してください。');
+    });
+
+    test('不正リクエストエラーを処理する', () {
+      final dioError = DioException(
+        type: DioExceptionType.badResponse,
+        response: Response(
+          statusCode: 400,
+          requestOptions: RequestOptions(path: ''),
+        ),
+        requestOptions: RequestOptions(path: ''),
+      );
+
+      final apiError = dioErrorHandler.handle(dioError);
+
+      expect(apiError.type, ApiErrorType.badRequest);
+      expect(apiError.message, 'リクエストが不正です。\n必須パラメータが欠如しているか、フォーマットが不正です。');
+    });
+
+    test('認証エラーを処理する', () {
+      final dioError = DioException(
+        type: DioExceptionType.badResponse,
+        response: Response(
+          statusCode: 401,
+          requestOptions: RequestOptions(path: ''),
+        ),
+        requestOptions: RequestOptions(path: ''),
+      );
+
+      final apiError = dioErrorHandler.handle(dioError);
+
+      expect(apiError.type, ApiErrorType.unauthorized);
+      expect(apiError.message, '認証されていません。\nAPIトークンが提供されていないか、アクセス権がありません。');
+    });
+
+    test('リソースが見つからないエラーを処理する', () {
+      final dioError = DioException(
+        type: DioExceptionType.badResponse,
+        response: Response(
+          statusCode: 404,
+          requestOptions: RequestOptions(path: ''),
+        ),
+        requestOptions: RequestOptions(path: ''),
+      );
+
+      final apiError = dioErrorHandler.handle(dioError);
+
+      expect(apiError.type, ApiErrorType.notFound);
+      expect(apiError.message, 'データが見つかりませんでした。\nリクエストパラメータに誤りがあります。');
+    });
+
+    test('リクエストが多すぎるエラーを処理する', () {
+      final dioError = DioException(
+        type: DioExceptionType.badResponse,
+        response: Response(
+          statusCode: 429,
+          requestOptions: RequestOptions(path: ''),
+        ),
+        requestOptions: RequestOptions(path: ''),
+      );
+
+      final apiError = dioErrorHandler.handle(dioError);
+
+      expect(apiError.type, ApiErrorType.tooManyRequests);
+      expect(apiError.message, 'リクエストが多すぎます。\nしばらく待ってから再試行してください。');
+    });
+
+    test('内部サーバーエラーを処理する', () {
+      final dioError = DioException(
+        type: DioExceptionType.badResponse,
+        response: Response(
+          statusCode: 500,
+          requestOptions: RequestOptions(path: ''),
+        ),
+        requestOptions: RequestOptions(path: ''),
+      );
+
+      final apiError = dioErrorHandler.handle(dioError);
+
+      expect(apiError.type, ApiErrorType.internalServerError);
+      expect(apiError.message, '内部サーバーエラーが発生しました。\nしばらくしてから再試行してください。');
+    });
+
+    test('不明なエラータイプを処理する', () {
+      final dioError = DioException(
+        type: DioExceptionType.unknown,
+        requestOptions: RequestOptions(path: ''),
+      );
+
+      final apiError = dioErrorHandler.handle(dioError);
+
+      expect(apiError.type, ApiErrorType.unknown);
+      expect(apiError.message, '不明なエラーが発生しました。\n後でもう一度お試しください。');
+    });
+
+    test('不明なステータスコードを処理する', () {
+      final dioError = DioException(
+        type: DioExceptionType.badResponse,
+        response: Response(
+          statusCode: 999,
+          requestOptions: RequestOptions(path: ''),
+        ),
+        requestOptions: RequestOptions(path: ''),
+      );
+
+      final apiError = dioErrorHandler.handle(dioError);
+
+      expect(apiError.type, ApiErrorType.unknown);
+      expect(apiError.message, '不明なエラーが発生しました。\n後でもう一度お試しください。');
+    });
+  });
+}


### PR DESCRIPTION
This PR introduces the `DioErrorHandler` class to handle and convert `DioException` into `ApiError` for more standardized error handling in the Weather App. It also includes unit tests for the `DioErrorHandler` class to ensure accurate error handling for various DioException types.

### Changes:
- **New Class**: `DioErrorHandler`
  - **Method**: `handle(DioException error)`
    - Converts `DioException` to `ApiError` based on the exception type and status code.
- **New Tests**: Unit tests for `DioErrorHandler`
  - Tests include:
    - Handling connection timeout
    - Handling send timeout
    - Handling receive timeout
    - Handling bad request (400)
    - Handling unauthorized (401)
    - Handling not found (404)
    - Handling too many requests (429)
    - Handling internal server errors (500, 502, 503, 504)
    - Handling unknown error types and status codes
- **New Provider**: `dioErrorHandlerProvider`
  - Provides an instance of `DioErrorHandler` for dependency injection.

These changes aim to improve the robustness and clarity of error handling within the app, ensuring that different error scenarios are managed consistently.

Please review the changes and merge this PR to integrate the new error handling mechanism.
