### PR TITLE
Add ApiService and Corresponding Tests

### DIFF
--- a/lib/core/network/response/api_service.dart
+++ b/lib/core/network/response/api_service.dart
@@ -1,0 +1,28 @@
+import 'package:dio/dio.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:weather_app/core/network/response/result.dart';
+import 'package:weather_app/view_model/providers/dio_error_handler_provider.dart';
+
+// ApiServiceクラスの定義
+class ApiService {
+  final Dio _dio;
+  final ProviderRef ref;
+
+  // コンストラクタでDioインスタンスとProviderRefを受け取る
+  ApiService(this._dio, this.ref);
+
+  // 一般的なGETリクエストを処理するメソッド
+  Future<Result<T>> get<T>(String url) async {
+    try {
+      // Dioを使ってGETリクエストを実行し、レスポンスを取得
+      final response = await _dio.get<T>(url);
+      // 成功した場合、Result.successにレスポンスデータを渡す
+      return Result.success(response.data as T);
+    } on DioException catch (e) {
+      // エラーが発生した場合、handleDioError関数でエラーを処理し、Result.failureを返す
+      final dioErrorHandler = ref.read(dioErrorHandlerProvider);
+      final apiError = dioErrorHandler.handle(e);
+      return Result.failure(apiError);
+    }
+  }
+}

--- a/test/core/network/response/api_service_test.dart
+++ b/test/core/network/response/api_service_test.dart
@@ -1,0 +1,80 @@
+import 'package:dio/dio.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mockito/mockito.dart';
+import 'package:weather_app/core/network/api_error.dart';
+import 'package:weather_app/core/network/dio_error_handler.dart';
+import 'package:weather_app/core/network/response/api_service.dart';
+import 'package:weather_app/core/network/response/result.dart';
+import 'package:weather_app/view_model/providers/dio_error_handler_provider.dart';
+
+import '../../../mocks/mock_dio.dart';
+import '../../../mocks/mock_provider_ref.dart';
+
+void main() {
+  group('ApiServiceのテスト', () {
+    late MockDio mockDio; // Dioのモック
+    late MockProviderRef mockRef; // ProviderRefのモック
+    late DioErrorHandler dioErrorHandler; // DioErrorHandlerのインスタンス
+    late ApiService apiService; // テスト対象のApiService
+
+    setUp(() {
+      // モックおよび依存関係の初期化
+      mockDio = MockDio();
+      mockRef = MockProviderRef();
+      dioErrorHandler = DioErrorHandler();
+
+      // ProviderRefのモックにDioErrorHandlerを設定
+      when(mockRef.read(dioErrorHandlerProvider)).thenReturn(dioErrorHandler);
+
+      // ApiServiceのインスタンスを作成
+      apiService = ApiService(mockDio, mockRef);
+    });
+
+    test('GETリクエスト成功', () async {
+      // テスト用のURLとデータを定義
+      const testUrl = 'https://api.example.com/data';
+      final testData = {'key': 'value'};
+
+      // モックのレスポンスを設定
+      when(mockDio.get<Map<String, dynamic>>(testUrl)).thenAnswer(
+        (_) async => Response<Map<String, dynamic>>(
+          data: testData,
+          statusCode: 200,
+          requestOptions: RequestOptions(path: testUrl),
+        ),
+      );
+
+      // API呼び出しを実行
+      final result = await apiService.get<Map<String, dynamic>>(testUrl);
+
+      // 成功結果の検証
+      expect(result, isA<Success<Map<String, dynamic>>>());
+      expect((result as Success<Map<String, dynamic>>).value, testData);
+    });
+
+    test('GETリクエスト失敗', () async {
+      // テスト用のURLを定義
+      const testUrl = 'https://api.example.com/data';
+
+      // 404エラーを模擬するDioExceptionを作成
+      final dioException = DioException(
+        requestOptions: RequestOptions(path: testUrl),
+        response: Response(
+          statusCode: 404,
+          requestOptions: RequestOptions(path: testUrl),
+        ),
+        type: DioExceptionType.badResponse,
+      );
+
+      // モックのエラーを設定
+      when(mockDio.get<Map<String, dynamic>>(testUrl)).thenThrow(dioException);
+
+      // API呼び出しを実行
+      final result = await apiService.get<Map<String, dynamic>>(testUrl);
+
+      // 失敗結果の検証
+      expect(result, isA<Failure>());
+      expect((result as Failure).error.type, ApiErrorType.notFound);
+    });
+  });
+}

--- a/test/mocks/mock_dio.dart
+++ b/test/mocks/mock_dio.dart
@@ -1,0 +1,38 @@
+import 'package:dio/dio.dart';
+import 'package:mockito/mockito.dart';
+
+// MockDioクラスの定義
+// Dioクラスをモック化して、テスト時に実際のHTTPリクエストを行わないようにします。
+class MockDio extends Mock implements Dio {
+  // getメソッドのオーバーライド
+  // Dioクラスのgetメソッドをオーバーライドして、モックの振る舞いを定義します。
+  @override
+  Future<Response<T>> get<T>(
+    String path, {
+    Map<String, dynamic>? queryParameters, // クエリパラメータ（GETリクエストのURLに追加される）
+    Options? options, // リクエストオプション（ヘッダー、タイムアウト設定など）
+    CancelToken? cancelToken, // リクエストキャンセル用のトークン
+    ProgressCallback? onReceiveProgress,
+    Object? data,
+  }) {
+    // レスポンスデータの受信進行状況を通知するコールバック
+    return super.noSuchMethod(
+      Invocation.method(#get, [
+        path
+      ], {
+        #queryParameters: queryParameters,
+        #options: options,
+        #cancelToken: cancelToken,
+        #onReceiveProgress: onReceiveProgress,
+        #data: data,
+      }),
+      // モックの戻り値を定義
+      // Future.valueを使用して、Future<Response<T>>型のレスポンスを即座に返します。
+      returnValue:
+          Future.value(Response<T>(requestOptions: RequestOptions(path: path))),
+      // メソッドがモックされていない場合の戻り値を定義
+      returnValueForMissingStub:
+          Future.value(Response<T>(requestOptions: RequestOptions(path: path))),
+    );
+  }
+}


### PR DESCRIPTION
This PR adds the implementation of the ApiService along with corresponding unit tests to ensure proper functionality and error handling. The changes include creating a mock Dio class for testing, defining the ApiService class to handle GET requests, and implementing tests to validate both successful and failed API calls.

### Changes:
1. **ApiService Implementation**:
   - **`lib/core/network/response/api_service.dart`**: 
     - Defines the `ApiService` class to handle GET requests using Dio.
     - Integrates error handling using the `DioErrorHandler`.

2. **Mocks and Test Setup**:
   - **`test/mocks/mock_dio.dart`**: 
     - Creates a mock Dio class to simulate HTTP requests during tests.
   - **`test/mocks/mock_provider_ref.dart`**:
     - Creates a mock ProviderRef class for testing purposes.

3. **Unit Tests for ApiService**:
   - **`test/core/network/response/api_service_test.dart`**:
     - Implements tests to validate the successful execution of GET requests.
     - Tests error handling by simulating various Dio exceptions.

### Files Added:
- `lib/core/network/response/api_service.dart`
- `test/mocks/mock_dio.dart`
- `test/mocks/mock_provider_ref.dart`
- `test/core/network/response/api_service_test.dart`

### How to Test:
1. Run the unit tests to ensure that the `ApiService` works correctly for both successful and failed API calls.
2. Verify that the error handling logic correctly translates Dio exceptions into appropriate `ApiError` instances.

Please review the changes and merge this PR to integrate the new `ApiService` and its tests.
