### PR TITLE
Integrate Dio for API Requests and Implement WeatherResultScreen

### DIFF
--- a/lib/core/network/dio_provider.dart
+++ b/lib/core/network/dio_provider.dart
@@ -1,9 +1,53 @@
 import 'package:dio/dio.dart';
+import 'package:flutter/foundation.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:weather_app/view_model/providers/dio_error_handler_provider.dart';
 
 // Dioインスタンスを提供するProvider
 // このProviderは、天気予報APIの通信に使用されるDioクライアントを提供します。
-// DioはHTTPクライアントライブラリで、APIとの通信を効率的に行うための機能を提供します。
+// 天気予報APIの通信に使用するHTTPクライアントとしてDioを設定
 final dioProvider = Provider<Dio>((ref) {
-  return Dio();
+  // Dioの基本設定を定義
+  final dio = Dio(BaseOptions(
+    connectTimeout: const Duration(seconds: 5), // 接続タイムアウトを5秒に設定
+    receiveTimeout: const Duration(seconds: 3), // 応答受信タイムアウトを3秒に設定
+    headers: {'Content-Type': 'application/json'}, // デフォルトのリクエストヘッダーをJSONに設定
+  ));
+
+  // DioErrorHandlerを読み込み、エラーハンドリングに使用
+  final dioErrorHandler = ref.read(dioErrorHandlerProvider);
+
+  // デバッグモードの場合のみログインターセプターを追加
+  if (kDebugMode) {
+    dio.interceptors.add(LogInterceptor(
+      requestHeader: true,
+      requestBody: true,
+      responseHeader: true,
+      responseBody: true,
+      error: true,
+    ));
+  }
+
+  // エラーハンドリング用インターセプターの設定
+  dio.interceptors.add(
+    InterceptorsWrapper(
+      onError: (DioException e, ErrorInterceptorHandler handler) {
+        // エラーハンドラーでDioExceptionを処理し、適切なApiErrorに変換
+        final apiError = dioErrorHandler.handle(e);
+
+        // 元のDioExceptionに変換後のApiErrorを適用
+        final newException = DioException(
+          type: e.type, // 元のエラータイプを維持
+          requestOptions: e.requestOptions,
+          response: e.response,
+          error: apiError, // ApiErrorに置き換え
+        );
+
+        // 新しいDioExceptionを次のハンドラーに渡す
+        handler.next(newException);
+      },
+    ),
+  );
+
+  return dio;
 });

--- a/lib/view/screens/weather_result_screen.dart
+++ b/lib/view/screens/weather_result_screen.dart
@@ -6,44 +6,65 @@ import 'package:weather_app/view_model/providers/city_weather_provider.dart';
 class WeatherResultScreen extends ConsumerWidget {
   final String cityName;
 
+  // コンストラクタ：必須のcityNameパラメータを受け取る
   const WeatherResultScreen({super.key, required this.cityName});
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    // FutureProviderを利用して天気情報を取得
+    // cityWeatherProviderを利用して天気情報を取得
     final weatherResult = ref.watch(cityWeatherProvider(cityName));
 
     return Scaffold(
       body: Center(
+        // データの状態に応じたウィジェットを返す
         child: weatherResult.when(
           // データ取得成功時の処理
           data: (data) {
-            return data.when(success: (weatherList) {
-              if (weatherList.isEmpty) {
-                return const Text('No weather data available');
-              }
-              final weather = weatherList.first;
-              return Column(
-                mainAxisAlignment: MainAxisAlignment.center,
-                children: [
-                  Text('都市名: $cityName'), // 都市名を表示
-                  Text(
-                      '気温: ${weather.main.temp.toStringAsFixed(1)}°C'), // 気温を表示
-                  Text('湿度: ${weather.main.humidity}%'), // 湿度を表示
-                  Text(
-                      '風速: ${weather.wind.speed.toStringAsFixed(1)}m/s'), // 風速を表示
-                  Text('天気: ${weather.weather.first.description}'), // 天気の説明を表示
-                ],
-              );
-            }, failure: (error) {
-              return Text('Error: ${error.message}'); // データ取得失敗時のエラーメッセージ
-            });
+            // 成功時のResultをさらに確認
+            return data.when(
+              success: (weatherList) {
+                if (weatherList.isEmpty) {
+                  // 天気データが空の場合の処理
+                  return const Text('天気データが利用できません');
+                }
+                // 最初の天気情報を取得
+                final weather = weatherList.first;
+                return Column(
+                  mainAxisAlignment: MainAxisAlignment.center,
+                  children: [
+                    Text('都市名: $cityName'), // 都市名を表示
+                    Text(
+                        '気温: ${weather.main.temp.toStringAsFixed(1)}°C'), // 気温を表示
+                    Text('湿度: ${weather.main.humidity}%'), // 湿度を表示
+                    Text(
+                        '風速: ${weather.wind.speed.toStringAsFixed(1)}m/s'), // 風速を表示
+                    Text(
+                        '天気: ${weather.weather.first.description}'), // 天気の説明を表示
+                  ],
+                );
+              },
+              failure: (error) {
+                // データ取得失敗時のエラーメッセージを表示
+                return Column(
+                  mainAxisAlignment: MainAxisAlignment.center,
+                  children: [
+                    Text('エラー: ${error.message}'), // エラーメッセージを表示
+                  ],
+                );
+              },
+            );
           },
-          // エラー発生時の処理
+          // 非同期処理でエラーが発生した場合の処理
           error: (e, s) {
-            return Text('Error: $e'); // 例外発生時のエラーメッセージ
+            // 例外発生時のエラーメッセージを表示
+            return Column(
+              mainAxisAlignment: MainAxisAlignment.center,
+              children: [
+                Text('例外が発生しました: $e'),
+              ],
+            );
           },
-          // ローディング中の処理
+          // データ取得中の処理
           loading: () => const CircularProgressIndicator(), // ローディングインジケーターを表示
         ),
       ),


### PR DESCRIPTION
This PR introduces the integration of the Dio HTTP client for API requests and implements the `WeatherResultScreen` to display weather information for a specified city.

### Overview:
1. **Dio Integration**:
   - Configured Dio with timeouts, default headers, and error handling using an interceptor.
   - Added logging for debug mode to help with API request and response inspection.
   - Error handling is centralized through a `DioErrorHandler` to convert `DioException` into meaningful `ApiError` objects.

2. **WeatherResultScreen**:
   - A new screen that displays the weather information of a specified city.
   - Uses Riverpod to manage and retrieve the weather data.
   - Handles different states including loading, success, and error, providing appropriate UI feedback for each state.

### Files Added/Modified:
- `lib/view_model/providers/dio_provider.dart`: Added a provider for Dio configuration and setup.
- `lib/screens/weather_result_screen.dart`: New screen for displaying weather information.

### How to Test:
1. Launch the application and navigate to the `WeatherResultScreen`.
2. Verify that the screen correctly displays weather information for a given city.
3. Ensure that API requests are logged in debug mode and errors are handled gracefully.

Please review the changes and merge this PR into `develop` to integrate the Dio HTTP client and the new weather display screen.