### PR TITLE
Adjust Background Image Darkness in WeatherResultScreen

### DIFF
--- a/lib/view/screens/weather_result_screen.dart
+++ b/lib/view/screens/weather_result_screen.dart
@@ -24,9 +24,13 @@ class WeatherResultScreen extends ConsumerWidget {
         children: [
           // 背景に画像を全画面で表示
           Positioned.fill(
-            child: Image.asset(
-              'assets/images/clouds-4215608_1280.jpg',
-              fit: BoxFit.cover,
+            child: ColorFiltered(
+              colorFilter: ColorFilter.mode(
+                  Colors.black.withOpacity(0.5), BlendMode.darken),
+              child: Image.asset(
+                'assets/images/clouds-4215608_1280.jpg',
+                fit: BoxFit.cover,
+              ),
             ),
           ),
           Center(


### PR DESCRIPTION
This PR adjusts the background image in the `WeatherResultScreen` by applying a darkening filter. This enhancement improves the readability of the text displayed on the screen.

### Overview:
1. **Background Image Adjustment**:
- Applied a `ColorFiltered` widget with a `ColorFilter` to darken the background image.
- This change makes the text easier to read by increasing the contrast between the text and the background.

2. **Improved User Experience**:
- Ensures that the weather information is clearly visible, regardless of the background image's brightness.

### Files Modified:
- `lib/view/screens/weather_result_screen.dart`: Updated to apply a darkening filter to the background image.

### How to Test:
1. Navigate to the `WeatherResultScreen` and ensure that the background image is properly darkened.
2. Verify that all text elements on the screen are easily readable against the darker background.

Please review the changes and merge this PR into `develop` to improve the visual clarity of the `WeatherResultScreen`.