### PR TITLE
Refactor: Extract background image into reusable `BackgroundImage` component

### DIFF
--- a/lib/components/background_image.dart
+++ b/lib/components/background_image.dart
@@ -1,0 +1,22 @@
+import 'package:flutter/material.dart';
+
+// BackgroundImageは画面全体に表示される背景画像ウィジェット
+class BackgroundImage extends StatelessWidget {
+  const BackgroundImage({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Positioned.fill(
+      child: ColorFiltered(
+        colorFilter: ColorFilter.mode(
+          Colors.black.withOpacity(0.5),
+          BlendMode.darken,
+        ),
+        child: Image.asset(
+          'assets/images/clouds-4215608_1280.jpg',
+          fit: BoxFit.cover,
+        ),
+      ),
+    );
+  }
+}

--- a/lib/view/screens/city_search_screen.dart
+++ b/lib/view/screens/city_search_screen.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_keyboard_visibility/flutter_keyboard_visibility.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:weather_app/components/background_image.dart';
 import 'package:weather_app/components/city_search_button.dart';
 import 'package:weather_app/components/city_search_input.dart';
 
@@ -10,18 +11,14 @@ class CitySearchScreen extends ConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    return KeyboardDismissOnTap(
+    return const KeyboardDismissOnTap(
       child: Scaffold(
         body: Stack(
           fit: StackFit.expand,
           children: [
-            // 背景画像
-            Image.asset(
-              'assets/images/clouds-4215608_1280.jpg',
-              fit: BoxFit.cover,
-            ),
+            BackgroundImage(),
             // 中央に検索インターフェイスを配置
-            const Center(
+            Center(
               child: SingleChildScrollView(
                 reverse: true,
                 child: Column(

--- a/lib/view/screens/error_display_screen.dart
+++ b/lib/view/screens/error_display_screen.dart
@@ -1,35 +1,31 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:weather_app/components/app_back_button.dart';
+import 'package:weather_app/components/background_image.dart';
 import 'package:weather_app/core/strings/dio_error_handler_strings.dart';
 import 'package:weather_app/view_model/providers/error_view_model_provider.dart';
 
+// ErrorDisplayScreenは、APIからのエラーメッセージを取得し、それを画面中央に表示する画面です。
 class ErrorDisplayScreen extends ConsumerWidget {
   const ErrorDisplayScreen({super.key});
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
+    // ErrorViewModelからエラー情報を取得
     final error = ref.watch(errorViewModelProvider).error;
+
+    // エラーメッセージがnullの場合、デフォルトメッセージを表示
     final errorMessage = error?.message ?? DioErrorHandlerStrings.unknownError;
 
     return Scaffold(
       body: Stack(
         children: [
-          // 背景に画像を全画面で表示
-          Positioned.fill(
-            child: ColorFiltered(
-              colorFilter: ColorFilter.mode(
-                  Colors.black.withOpacity(0.5), BlendMode.darken),
-              child: Image.asset(
-                'assets/images/clouds-4215608_1280.jpg',
-                fit: BoxFit.cover,
-              ),
-            ),
-          ),
+          const BackgroundImage(),
           Center(
             child: Column(
               mainAxisAlignment: MainAxisAlignment.center,
               children: [
+                // エラーメッセージを表示
                 Text(
                   errorMessage,
                   style: const TextStyle(
@@ -39,7 +35,7 @@ class ErrorDisplayScreen extends ConsumerWidget {
                   ),
                   textAlign: TextAlign.center,
                 ),
-                const AppBackButton(),
+                const AppBackButton(), // 戻るボタン
               ],
             ),
           ),

--- a/lib/view/screens/weather_result_screen.dart
+++ b/lib/view/screens/weather_result_screen.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:weather_app/components/app_back_button.dart';
+import 'package:weather_app/components/background_image.dart';
 import 'package:weather_app/components/city_name_text.dart';
 import 'package:weather_app/components/humidity_text.dart';
 import 'package:weather_app/components/temperature_text.dart';
@@ -27,17 +28,7 @@ class _WeatherResultScreenState extends ConsumerState<WeatherResultScreen> {
     return Scaffold(
       body: Stack(
         children: [
-          // 背景に画像を全画面で表示
-          Positioned.fill(
-            child: ColorFiltered(
-              colorFilter: ColorFilter.mode(
-                  Colors.black.withOpacity(0.5), BlendMode.darken),
-              child: Image.asset(
-                'assets/images/clouds-4215608_1280.jpg',
-                fit: BoxFit.cover,
-              ),
-            ),
-          ),
+          const BackgroundImage(),
           Center(
             // データの状態に応じたウィジェットを返す
             child: weatherResult.when(


### PR DESCRIPTION


### Description
This pull request refactors the app by extracting the background image logic into a reusable `BackgroundImage` component. The goal is to reduce code duplication and improve maintainability by centralizing the background image implementation, which is now reused across multiple screens.

### Key Changes

#### 1. New `BackgroundImage` component
- Created a new `BackgroundImage` widget that displays the background image with a dark color filter.
- This component is now used in multiple screens to maintain consistency in the background styling.

#### 2. Screens Updated to Use `BackgroundImage`
- **ErrorDisplayScreen**: Replaced the previous inline background image logic with the new `BackgroundImage` component.
- **WeatherResultScreen**: Refactored to use the `BackgroundImage` component for displaying the background.
- **CitySearchScreen**: The screen now also uses the `BackgroundImage` component for consistent UI styling.

### Files Modified

#### New File:
- `lib/components/background_image.dart`: The newly created reusable `BackgroundImage` component.

#### Modified Files:
- `lib/view/screens/error_display_screen.dart`: Refactored to use the new `BackgroundImage` component.
- `lib/view/screens/weather_result_screen.dart`: Refactored to use the new `BackgroundImage` component.
- `lib/view/screens/city_search_screen.dart`: Updated to use the `BackgroundImage` component.

### Benefits
- **Code Reusability**: The background image logic is now centralized in one component, which reduces duplication across the app and makes it easier to modify the background behavior or appearance.
- **Consistency**: Ensures a consistent appearance for the background across different screens.
- **Maintainability**: Future changes to the background image or styling can be made in a single location.