### PR TITLE
Improve UI Spacing in ErrorDisplayScreen and WeatherResultScreen

### DIFF
--- a/lib/view/screens/error_display_screen.dart
+++ b/lib/view/screens/error_display_screen.dart
@@ -36,6 +36,7 @@ class ErrorDisplayScreen extends ConsumerWidget {
                   ),
                   textAlign: TextAlign.center,
                 ),
+                const SizedBox(height: 20),
                 const AppBackButton(), // 戻るボタン
               ],
             ),

--- a/lib/view/screens/weather_result_screen.dart
+++ b/lib/view/screens/weather_result_screen.dart
@@ -60,7 +60,7 @@ class _WeatherResultScreenState extends ConsumerState<WeatherResultScreen> {
                         WeatherIcon(
                             iconCode:
                                 "${weather.weather.first.icon}@2x"), // 天気アイコン
-                        const SizedBox(height: 8),
+                        const SizedBox(height: 20),
                         const AppBackButton(), // 戻るボタン
                       ],
                     );


### PR DESCRIPTION
## **Description**
This pull request addresses UI improvements by adding spacing between elements to enhance visual balance and usability in the `ErrorDisplayScreen` and `WeatherResultScreen`.

---

## **Key Changes**
1. **Added Spacing to `ErrorDisplayScreen`**: Introduced `SizedBox` to provide better visual separation between the error message and the back button.
2. **Adjusted Spacing in `WeatherResultScreen`**: Updated the spacing between the weather icon and the back button for improved UI consistency.
3. **Minor Refactoring**: Adjusted spacing values for uniformity across screens.

---

## **Files Modified**
- **`lib/view/screens/error_display_screen.dart`**: Added a `SizedBox` with `height: 20` to improve spacing between the error message and the back button.
- **`lib/view/screens/weather_result_screen.dart`**: Updated the `SizedBox` height from `8` to `20` for better layout consistency.

---

## **How to Test**
1. **Manual Testing:**
   - [ ] Navigate to the `ErrorDisplayScreen` and confirm that the error message and back button have proper spacing.
   - [ ] Navigate to the `WeatherResultScreen` and verify the spacing adjustment between the weather icon and back button.

2. **Automated Testing:**
   - Ensure all existing tests pass without errors.
   - No new tests are required as this is a visual/UI update.

---

## **Benefits**
- **Improved UX**: Provides a more polished and visually balanced layout for users.
- **Code Maintainability**: Ensures consistent spacing across similar components.

---

## **Screenshots (if applicable)**
- N/A

---

## **Related Issues**
- N/A

---

## **Additional Notes**
No additional notes.
