### PR TITLE
Refactor: Replace SizedBox with Gap for better readability

### DIFF
--- a/lib/view/screens/city_search_screen.dart
+++ b/lib/view/screens/city_search_screen.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_keyboard_visibility/flutter_keyboard_visibility.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:gap/gap.dart';
 
 import '../../components/background_image.dart';
 import '../../components/city_search_button.dart';
@@ -25,13 +26,13 @@ class CitySearchScreen extends ConsumerWidget {
                 child: Column(
                   mainAxisAlignment: MainAxisAlignment.center,
                   children: [
-                    SizedBox(height: 20),
+                    Gap(20),
                     Padding(
                       padding: EdgeInsets.symmetric(horizontal: 40.0),
                       // 都市名入力用のウィジェット
                       child: CitySearchInput(),
                     ),
-                    SizedBox(height: 20),
+                    Gap(20),
                     // 検索ボタンウィジェット
                     CitySearchButton(),
                   ],

--- a/lib/view/screens/error_display_screen.dart
+++ b/lib/view/screens/error_display_screen.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:gap/gap.dart';
 
 import '../../components/app_back_button.dart';
 import '../../components/background_image.dart';
@@ -36,7 +37,7 @@ class ErrorDisplayScreen extends ConsumerWidget {
                   ),
                   textAlign: TextAlign.center,
                 ),
-                const SizedBox(height: 20),
+                Gap(20),
                 const AppBackButton(), // 戻るボタン
               ],
             ),

--- a/lib/view/screens/weather_result_screen.dart
+++ b/lib/view/screens/weather_result_screen.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:gap/gap.dart';
 
 import '../../components/app_back_button.dart';
 import '../../components/background_image.dart';
@@ -46,21 +47,21 @@ class _WeatherResultScreenState extends ConsumerState<WeatherResultScreen> {
                       children: [
                         CityNameText(
                             cityName: weatherResponse.city.name), // 都市名
-                        const SizedBox(height: 8),
+                        Gap(8),
                         TemperatureText(temperature: weather.main.temp), // 気温
-                        const SizedBox(height: 8),
+                        Gap(8),
                         HumidityText(humidity: weather.main.humidity), // 湿度
-                        const SizedBox(height: 8),
+                        Gap(8),
                         WindSpeedText(windSpeed: weather.wind.speed), // 風速
-                        const SizedBox(height: 8),
+                        Gap(8),
                         WeatherDescriptionText(
                             weatherDescription:
                                 weather.weather.first.description), // 天気の説明
-                        const SizedBox(height: 8),
+                        Gap(8),
                         WeatherIcon(
                             iconCode:
                                 "${weather.weather.first.icon}@2x"), // 天気アイコン
-                        const SizedBox(height: 20),
+                        Gap(20),
                         const AppBackButton(), // 戻るボタン
                       ],
                     );

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -485,6 +485,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "4.0.0"
+  gap:
+    dependency: "direct main"
+    description:
+      name: gap
+      sha256: f19387d4e32f849394758b91377f9153a1b41d79513ef7668c088c77dbc6955d
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.0.1"
   glob:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -31,6 +31,7 @@ dependencies:
   firebase_core: ^3.10.1
   firebase_crashlytics: ^4.3.1
   firebase_analytics: ^11.4.1
+  gap: ^3.0.1
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
## **Description**
This pull request replaces `SizedBox` with the `gap` package to improve code readability and maintainability.

---

## **Key Changes**
1. **Replaced `SizedBox` with `Gap`**: Updated multiple screens to use `Gap` instead of `SizedBox` for spacing.
2. **Imported `gap` package**: Added the `gap` package in `pubspec.yaml` and updated `pubspec.lock`.
3. **Refactoring**: Improved consistency in spacing management across the app.

---

## **Files Added**
- N/A

---

## **Files Modified**
- **`lib/view/screens/city_search_screen.dart`**: Replaced `SizedBox` with `Gap`.
- **`lib/view/screens/error_display_screen.dart`**: Replaced `SizedBox` with `Gap`.
- **`lib/view/screens/weather_result_screen.dart`**: Replaced `SizedBox` with `Gap`.
- **`pubspec.yaml`**: Added `gap` package.
- **`pubspec.lock`**: Updated dependencies.

---

## **How to Test**
1. **Manual Testing:**
- [ ] Open the app and navigate to the City Search screen.
- [ ] Ensure that spacing between elements is consistent.
- [ ] Navigate to the Error Display and Weather Result screens and verify spacing.

2. **Automated Testing:**
- Ensure all existing widget and unit tests pass.
- No new tests are required since this is a UI refactoring.

---

## **Benefits**
- **Improved UX**: More consistent and maintainable spacing across the app.
- **Code Maintainability**: Reduces redundant `SizedBox` usage and simplifies spacing logic.
- **Performance Enhancements**: Minor optimization by using `Gap`, which is designed for this purpose.

---

## **Screenshots (if applicable)**
- N/A

---

## **Related Issues**
- N/A

---

## **Additional Notes**
No functional changes—purely a refactor for better readability and maintainability.