### PR TITLE
chore: add GitHub Actions workflow to auto-assign PR author

### DIFF
--- a/.github/workflows/pull_request_ci.yml
+++ b/.github/workflows/pull_request_ci.yml
@@ -1,0 +1,12 @@
+name: Pull Request CI
+
+on:
+  pull_request:
+    types: [opened]
+
+jobs:
+  author:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Assign PR Author
+        uses: technote-space/assign-author@v1.3.1


### PR DESCRIPTION
## **Description**
This pull request introduces a new GitHub Actions workflow to automatically assign the PR author as the assignee. This ensures that every pull request has a designated owner, improving contribution tracking and PR management.

---

## **Key Changes**
1. **Added `.github/workflows/pull_request_ci.yml`**: Introduced a new GitHub Actions workflow that runs when a pull request is opened.
2. **Automated PR author assignment**: Utilizes `technote-space/assign-author@v1.3.1` to automatically assign the PR creator.
3. **Enhanced PR management**: Ensures every PR has an assignee from the beginning, improving workflow efficiency.

---

## **Files Added**
- `.github/workflows/pull_request_ci.yml`: Defines a GitHub Actions workflow to automatically assign the PR author.

---

## **Files Modified**
_None_

---

## **How to Test**
1. **Manual Testing:**
- [ ] Open a new pull request.
- [ ] Verify that the PR creator is automatically assigned as the assignee.

2. **Automated Testing:**
- No additional tests required, as this is a CI workflow change.

---

## **Benefits**
- **Improved PR tracking**: Ensures that every PR has a clearly assigned owner.
- **Reduced manual effort**: Removes the need for manually assigning PR authors.
- **Better workflow management**: Helps maintainers quickly identify responsible contributors.

---

## **Screenshots (if applicable)**
- N/A

---

## **Related Issues**
- N/A

---

## **Additional Notes**
This change is part of ongoing CI/CD improvements to streamline PR handling and enhance development workflow automation.
