### PR TITLE
chore(ci): update PR author assignment action to v1.6.2

### DIFF
--- a/.github/workflows/pull_request_ci.yml
+++ b/.github/workflows/pull_request_ci.yml
@@ -9,4 +9,4 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Assign PR Author
-        uses: technote-space/assign-author@v1.3.1
+        uses: technote-space/assign-author@v1.6.2


### PR DESCRIPTION
## **Description**
This pull request updates the GitHub Actions workflow for automatically assigning PR authors. 
The `technote-space/assign-author` action has been upgraded from **v1.3.1** to **v1.6.2** to ensure compatibility with the latest version and improve stability.

---

## **Key Changes**
1. **Upgrade GitHub Action Version**: 
- Updated `technote-space/assign-author` from v1.3.1 to v1.6.2.
- Ensures compatibility with the latest action version.
2. **Improve PR Automation Workflow**: 
- Enhances stability and maintainability of the PR assignment process.

---

## **Files Modified**
- **`.github/workflows/pull_request_ci.yml`**: 
- Updated the GitHub Actions workflow to use `technote-space/assign-author@v1.6.2`.

---

## **How to Test**
1. **Manual Testing:**
- [ ] Open a new pull request.
- [ ] Confirm that the PR author is automatically assigned.

2. **Automated Testing:**
- N/A (Relies on GitHub Actions execution).

---

## **Benefits**
- **Ensures compatibility** with the latest version of `technote-space/assign-author`.
- **Improves stability** of PR automation workflow.
- **Enhances maintainability** of CI configurations.

---

## **Screenshots (if applicable)**
_None needed._

---

## **Related Issues**
- N/A

---

## **Additional Notes**
_No additional notes._