### PR TITLE
fix: revert commit 24de1fa and clean up Firebase CI config

### DIFF
--- a/.github/workflows/firebase_functions_ci.yml
+++ b/.github/workflows/firebase_functions_ci.yml
@@ -34,20 +34,20 @@ jobs:
       - name: Set up Firebase credentials
         run: |
           echo "$FIREBASE_SERVICE_ACCOUNT_TEST" | tr -d '\n' | base64 --decode > $HOME/service-account.json
-          echo "GOOGLE_APPLICATION_CREDENTIALS=$HOME/service-account.json" >> $GITHUB_ENV
+          echo "GOOGLE_APPLICATION_CREDENTIALS_TEST=$HOME/service-account.json" >> $GITHUB_ENV
         env:
           FIREBASE_SERVICE_ACCOUNT_TEST: ${{ secrets.FIREBASE_SERVICE_ACCOUNT_TEST }}
 
       - name: Configure Test Environment
         run: |
           echo "OPENWEATHERMAP_API_KEY_DEV=${{ secrets.OPENWEATHERMAP_API_KEY_DEV }}" >> $GITHUB_ENV
-          echo "FIREBASE_PROJECT_ID=${{ secrets.FIREBASE_PROJECT_ID_TEST }}" >> $GITHUB_ENV  # シンプルにする
+          echo "FIREBASE_PROJECT_ID=${{ secrets.FIREBASE_PROJECT_ID_TEST }}" >> $GITHUB_ENV  
           echo "NODE_ENV=${{ env.NODE_ENV }}" >> $GITHUB_ENV
 
       - name: Verify Firebase credentials
         run: |
-          if [ ! -f "$GOOGLE_APPLICATION_CREDENTIALS" ]; then
-            echo "Error: GOOGLE_APPLICATION_CREDENTIALS file not found!"
+          if [ ! -f "$GOOGLE_APPLICATION_CREDENTIALS_TEST" ]; then
+            echo "Error: GOOGLE_APPLICATION_CREDENTIALS_TEST file not found!"
             exit 1
           fi
         shell: bash

--- a/.github/workflows/firebase_functions_ci.yml
+++ b/.github/workflows/firebase_functions_ci.yml
@@ -34,20 +34,20 @@ jobs:
       - name: Set up Firebase credentials
         run: |
           echo "$FIREBASE_SERVICE_ACCOUNT_TEST" | tr -d '\n' | base64 --decode > $HOME/service-account.json
-          echo "GOOGLE_APPLICATION_CREDENTIALS_TEST=$HOME/service-account.json" >> $GITHUB_ENV
+          echo "GOOGLE_APPLICATION_CREDENTIALS=$HOME/service-account.json" >> $GITHUB_ENV
         env:
           FIREBASE_SERVICE_ACCOUNT_TEST: ${{ secrets.FIREBASE_SERVICE_ACCOUNT_TEST }}
 
       - name: Configure Test Environment
         run: |
           echo "OPENWEATHERMAP_API_KEY_DEV=${{ secrets.OPENWEATHERMAP_API_KEY_DEV }}" >> $GITHUB_ENV
-          echo "FIREBASE_PROJECT_ID=${{ secrets.FIREBASE_PROJECT_ID_TEST }}" >> $GITHUB_ENV  
+          echo "FIREBASE_PROJECT_ID=${{ secrets.FIREBASE_PROJECT_ID_TEST }}" >> $GITHUB_ENV  # シンプルにする
           echo "NODE_ENV=${{ env.NODE_ENV }}" >> $GITHUB_ENV
 
       - name: Verify Firebase credentials
         run: |
-          if [ ! -f "$GOOGLE_APPLICATION_CREDENTIALS_TEST" ]; then
-            echo "Error: GOOGLE_APPLICATION_CREDENTIALS_TEST file not found!"
+          if [ ! -f "$GOOGLE_APPLICATION_CREDENTIALS" ]; then
+            echo "Error: GOOGLE_APPLICATION_CREDENTIALS file not found!"
             exit 1
           fi
         shell: bash

--- a/.github/workflows/firebase_functions_ci.yml
+++ b/.github/workflows/firebase_functions_ci.yml
@@ -41,7 +41,7 @@ jobs:
       - name: Configure Test Environment
         run: |
           echo "OPENWEATHERMAP_API_KEY_DEV=${{ secrets.OPENWEATHERMAP_API_KEY_DEV }}" >> $GITHUB_ENV
-          echo "FIREBASE_PROJECT_ID=${{ secrets.FIREBASE_PROJECT_ID_TEST }}" >> $GITHUB_ENV  # シンプルにする
+          echo "FIREBASE_PROJECT_ID=${{ secrets.FIREBASE_PROJECT_ID_TEST }}" >> $GITHUB_ENV  
           echo "NODE_ENV=${{ env.NODE_ENV }}" >> $GITHUB_ENV
 
       - name: Verify Firebase credentials


### PR DESCRIPTION
## **Description** 
This pull request reverts the changes made in commit `24de1fa`, restoring the Firebase credentials environment variable in the GitHub Actions CI workflow to match the `develop` branch. 
Additionally, unnecessary comments have been removed to improve readability and maintainability.

---

## **Key Changes** 
1. **Reverted Firebase Credentials Variable**: 
- Restored `GOOGLE_APPLICATION_CREDENTIALS` instead of `GOOGLE_APPLICATION_CREDENTIALS_TEST` in the CI workflow. 
- Ensured consistency with the `develop` branch. 
2. **Removed Unnecessary Comments**: 
- Deleted redundant comments to improve maintainability. 
- Kept only relevant information for clarity.

---

## **Files Modified** 
- **`.github/workflows/firebase_functions_ci.yml`** 
- Reverted `GOOGLE_APPLICATION_CREDENTIALS_TEST` to `GOOGLE_APPLICATION_CREDENTIALS`. 
- Removed unnecessary comments that were not contributing to the clarity of the configuration. 

---

## **How to Test** 
1. **Manual Testing:** 
- [ ] Trigger the GitHub Actions workflow on a pull request. 
- [ ] Verify that the Firebase authentication step completes successfully. 
- [ ] Ensure that no errors related to missing credentials appear in the logs. 

2. **Automated Testing:** 
- CI workflow should pass without credential-related failures. 

---

## **Benefits** 
- **Restores CI Compatibility**: Ensures the workflow remains aligned with the `develop` branch. 
- **Prevents Authentication Issues**: Uses the correct environment variable to avoid potential failures. 
- **Improves Maintainability**: Removes unnecessary comments for better readability. 

---

## **Related Issues** 
- N/A 

---

## **Additional Notes** 
- This change only affects CI and does not impact application logic. 
- If further authentication issues arise, secret storage settings in GitHub Actions should be verified. 