### PR TITLE
Fix: Show user-friendly error messages instead of internal codes

### DIFF
--- a/lib/core/extensions/api_error_type_messages.dart
+++ b/lib/core/extensions/api_error_type_messages.dart
@@ -1,0 +1,25 @@
+import '../network/api_error.dart';
+
+/// [ApiErrorType] に対するUI表示メッセージ拡張
+extension ApiErrorTypeMessages on ApiErrorType {
+  String get displayMessage {
+    switch (this) {
+      case ApiErrorType.timeout:
+        return '接続タイムアウトが発生しました。\nネットワークの状態を確認してください。';
+      case ApiErrorType.cancel:
+        return 'リクエストがキャンセルされました。';
+      case ApiErrorType.badRequest:
+        return 'リクエストが不正です。\n必須パラメータが欠如しているか、フォーマットが不正です。';
+      case ApiErrorType.unauthorized:
+        return '認証されていません。\nAPIトークンが提供されていないか、アクセス権がありません。';
+      case ApiErrorType.notFound:
+        return 'データが見つかりませんでした。\nリクエストパラメータに誤りがあります。';
+      case ApiErrorType.tooManyRequests:
+        return 'リクエストが多すぎます。\nしばらく待ってから再試行してください。';
+      case ApiErrorType.internalServerError:
+        return '内部サーバーエラーが発生しました。\nしばらくしてから再試行してください。';
+      case ApiErrorType.unknown:
+        return '不明なエラーが発生しました。\n後でもう一度お試しください。';
+    }
+  }
+}

--- a/lib/core/extensions/api_error_ui_message.dart
+++ b/lib/core/extensions/api_error_ui_message.dart
@@ -1,0 +1,8 @@
+import '../../core/network/api_error.dart';
+import 'api_error_type_messages.dart';
+
+extension ApiErrorUIMessage on ApiError {
+  String get uiMessage {
+    return type.displayMessage;
+  }
+}

--- a/lib/core/network/api_error.dart
+++ b/lib/core/network/api_error.dart
@@ -4,38 +4,19 @@ part 'api_error.freezed.dart';
 
 /// [ApiErrorType] 列挙型は、APIエラーの種類を定義します。
 enum ApiErrorType {
-  /// タイムアウトエラー
   timeout,
-
-  /// リクエストのキャンセル
   cancel,
-
-  /// 不正なリクエスト
   badRequest,
-
-  /// 認証エラー
   unauthorized,
-
-  /// リソースが見つからない
   notFound,
-
-  /// リクエストが多すぎる
   tooManyRequests,
-
-  /// サーバー内部エラー
   internalServerError,
-
-  /// 不明なエラー
   unknown,
 }
 
 /// [ApiError] クラスは、APIエラーを表現します。
 @freezed
 class ApiError with _$ApiError {
-  /// コンストラクタ。
-  ///
-  /// [type] : エラーの種類を表す [ApiErrorType]。
-  /// [message] : エラーメッセージ。
   const factory ApiError({
     required ApiErrorType type,
     required String message,

--- a/lib/view/screens/error_display_screen.dart
+++ b/lib/view/screens/error_display_screen.dart
@@ -4,6 +4,7 @@ import 'package:gap/gap.dart';
 
 import '../../components/app_back_button.dart';
 import '../../components/background_image.dart';
+import '../../core/extensions/api_error_ui_message.dart';
 import '../../core/strings/dio_error_handler_strings.dart';
 import '../../view_model/providers/error_view_model_provider.dart';
 
@@ -17,7 +18,8 @@ class ErrorDisplayScreen extends ConsumerWidget {
     final error = ref.watch(errorViewModelProvider).error;
 
     // エラーメッセージがnullの場合、デフォルトメッセージを表示
-    final errorMessage = error?.message ?? DioErrorHandlerStrings.unknownError;
+    final errorMessage =
+        error?.uiMessage ?? DioErrorHandlerStrings.unknownError;
 
     return Scaffold(
       body: Stack(


### PR DESCRIPTION
## **Description**
This pull request resolves the issue of technical error messages like `INTERNAL` being displayed in the UI. 
It introduces extension-based message handling to map `ApiErrorType` to user-friendly Japanese messages. 
The update improves user experience and sets the stage for future localization (i18n).

---

## **Key Changes**
1. **Feature**: Added `displayMessage` extension to `ApiErrorType` for user-facing messages.
2. **Feature**: Added `uiMessage` extension to `ApiError` to delegate display logic from the model.
3. **Refactoring**: Replaced raw `.message` usage in the UI with `.uiMessage` for consistency and clarity.

---

## **Files Added**
- `lib/core/extensions/api_error_type_messages.dart`: Maps `ApiErrorType` values to localized display messages.
- `lib/core/extensions/api_error_ui_message.dart`: Provides a `uiMessage` getter on `ApiError` for UI use.

---

## **Files Modified**
- **`lib/core/network/api_error.dart`**: Cleaned up comments to reflect responsibility shift to extensions.
- **`lib/view/screens/error_display_screen.dart`**: Replaced `error.message` with `error.uiMessage` for user-friendly display.

---

## **How to Test**
1. **Manual Testing:**
- [ ] Enter an invalid city name or disconnect from the network.
- [ ] Confirm that meaningful Japanese messages are shown instead of `INTERNAL` or other technical strings.

2. **Automated Testing:**
- [ ] Run `flutter test` and verify all existing tests pass.

---

## **Benefits**
- **Improved UX**: Users receive context-aware error messages in their language.
- **Code Maintainability**: Centralized message handling logic improves scalability and readability.
- **Future-Ready**: Prepares the app for future internationalization support.

---

## **Screenshots (if applicable)**
- N/A

---

## **Related Issues**
- N/A

---

## **Additional Notes**
This pattern can be extended to support localization libraries or centralized string resources in the future.