### PR TITLE
Apply Noto Sans JP via google_fonts for consistent Japanese typography

### DIFF
--- a/lib/core/theme/app_theme.dart
+++ b/lib/core/theme/app_theme.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:google_fonts/google_fonts.dart';
 
 /// アプリケーション全体のテーマ設定を提供します。
 class AppTheme {
@@ -16,13 +17,13 @@ class AppTheme {
       secondary: secondaryColor,
       surface: backgroundColor,
     ),
-    textTheme: const TextTheme(
-      displayLarge: TextStyle(
+    textTheme: GoogleFonts.notoSansJpTextTheme().copyWith(
+      displayLarge: GoogleFonts.notoSansJp(
         fontSize: 24,
         fontWeight: FontWeight.bold,
         color: Colors.black87,
       ),
-      bodyLarge: TextStyle(
+      bodyLarge: GoogleFonts.notoSansJp(
         fontSize: 16,
         color: Colors.black87,
       ),

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -573,6 +573,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "14.3.0"
+  google_fonts:
+    dependency: "direct main"
+    description:
+      name: google_fonts
+      sha256: b1ac0fe2832c9cc95e5e88b57d627c5e68c223b9657f4b96e1487aa9098c7b82
+      url: "https://pub.dev"
+    source: hosted
+    version: "6.2.1"
   graphs:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -33,6 +33,7 @@ dependencies:
   cloud_functions: ^5.3.4
   cloud_firestore: ^5.6.5
   flutter_launcher_icons: ^0.14.3
+  google_fonts: ^6.2.1
 
 dev_dependencies:
   build_runner: ^2.4.9 


### PR DESCRIPTION
## **Description**
This pull request introduces Japanese font support across the application by integrating the `google_fonts` package and applying `Noto Sans JP` as the default font throughout the theme.

---

## **Key Changes**
1. **Google Fonts Integration**: Added `google_fonts` package to support custom font usage.
2. **Typography Update**: Applied `Noto Sans JP` to the global `AppTheme` for consistent Japanese text rendering.
3. **Refactoring**: Modified `textTheme` structure to use `GoogleFonts.notoSansJpTextTheme()` with custom overrides.

---

## **Files Added**
*No new files were added.*

---

## **Files Modified**
- **`pubspec.yaml`**: Added `google_fonts: ^6.2.1` to dependencies.
- **`pubspec.lock`**: Locked `google_fonts` to version 6.2.1.
- **`lib/core/theme/app_theme.dart`**: Updated theme to use `Noto Sans JP` via Google Fonts.

---

## **How to Test**
1. **Manual Testing:**
- [ ] Run the app and verify all text elements use `Noto Sans JP`.
- [ ] Check for proper font rendering in various widgets (AppBar, Button, Body text, etc.).

2. **Automated Testing:**
- Run existing tests with `fvm flutter test`.
- No new tests were added, visual inspection required for font changes.

---

## **Benefits**
- **Improved UX**: Enhances readability for Japanese users with a clear and modern font.
- **Visual Consistency**: Matches the tone of branding and aligns with localized UI.
- **Scalability**: Prepares the app for multilingual typography support.

---

## **Screenshots (if applicable)**
- N/A

---

## **Related Issues**
- N/A

---

## **Additional Notes**
Ensure that your development environment has access to fetch Google Fonts. This change affects all text rendered using the default theme.