### PR TITLE
fix: prevent reuse of outdated weather cache across days

### DIFF
--- a/functions/src/weather_controller.ts
+++ b/functions/src/weather_controller.ts
@@ -36,9 +36,13 @@ export const getWeatherForCity = functions.https.onCall(
       if (currentSnapshot.exists) {
         const currentData = currentSnapshot.data();
         const dataTimestamp = currentData?.timestamp ?? 0;
+
+        const currentDataDate = new Date(dataTimestamp * 1000).toDateString(); // 秒→ms
+        const nowDate = new Date().toDateString(); // 現在のUTC日付
         const diff = now - dataTimestamp;
 
-        if (diff < CACHE_DURATION_SECONDS) {
+        // 6時間以内かつデータが今日のものである場合のみキャッシュを使用
+        if (diff < CACHE_DURATION_SECONDS && currentDataDate === nowDate) {
           console.log(`Firestoreキャッシュから${city}の天気データを取得（再取得不要）`);
 
           // Firestoreから5日間の予報を取得

--- a/functions/test/weather_controller_test.ts
+++ b/functions/test/weather_controller_test.ts
@@ -118,6 +118,7 @@ describe("getWeatherForCityの動作検証 (Cloud Functions)", () => {
       description: "雲",
       icon: "04d",
     });
+
     assert.isFalse(fetchWeatherStub.called);
   });
 
@@ -129,10 +130,49 @@ describe("getWeatherForCityの動作検証 (Cloud Functions)", () => {
       rawRequest: {},
       auth: null,
     } as unknown as functions.https.CallableRequest<unknown>;
+
     const result = await wrapped(mockRequest);
 
     assert.isTrue(fetchWeatherStub.calledOnce);
     assert.isTrue(saveWeatherStub.calledOnce);
+
+    expect(result.current).to.deep.include({
+      city: "Tokyo",
+      temperature: 8.98,
+      humidity: 27,
+      windSpeed: 9.77,
+      description: "雲",
+      icon: "04d",
+    });
+  });
+
+  it("Firestoreに昨日の日付のデータがある場合、APIを呼び出す", async () => {
+    const yesterdayTimestamp = Math.floor((Date.now() - 24 * 60 * 60 * 1000) / 1000); // 昨日
+
+    getStub.resolves({
+      exists: true,
+      data: () => ({
+        city: "Tokyo",
+        temperature: 12.34,
+        humidity: 50,
+        windSpeed: 3.21,
+        description: "曇り",
+        icon: "03d",
+        timestamp: yesterdayTimestamp, // 昨日のデータ
+      }),
+    } as unknown);
+
+    const mockRequest = {
+      data: { city: "Tokyo" },
+      rawRequest: {},
+      auth: null,
+    } as unknown as functions.https.CallableRequest<unknown>;
+
+    const result = await wrapped(mockRequest);
+
+    assert.isTrue(fetchWeatherStub.calledOnce, "APIが呼び出されるべき");
+    assert.isTrue(saveWeatherStub.calledOnce, "Firestore保存が行われるべき");
+
     expect(result.current).to.deep.include({
       city: "Tokyo",
       temperature: 8.98,


### PR DESCRIPTION
## **Description**
This pull request addresses an issue where outdated weather data could be shown past midnight due to time-based caching alone. 
To resolve this, a date-based validation has been added to the weather caching logic.

---

## **Key Changes**
1. **Added date comparison** to cache validation to prevent reuse of previous day's weather data even within a valid timestamp range.
2. **Improved cache logic** to ensure current weather data is only used if it matches today's date.
3. **(Optional)** Added a test to validate cache invalidation logic across midnight (can be removed if tests are excluded).

---

## **Files Modified**
- **`functions/src/weather_controller.ts`**: Added date-based validation to ensure cache is from the same day.

---

## **How to Test**
1. **Manual Testing:**
- [ ] Deploy Cloud Function
- [ ] Call the `getWeatherForCity` function after 00:00 with weather data cached at 23:59 of the previous day
- [ ] Confirm that new data is fetched from the API (not from Firestore cache)

2. **Automated Testing:**
- Run existing Cloud Functions tests (if retained)
- If testing is omitted for now, manual verification is sufficient

---

## **Benefits**
- **Improved UX**: Prevents users from seeing outdated weather data after midnight.
- **Code Maintainability**: Clear separation between time-based and date-based cache validation.
- **Correctness**: Ensures logic aligns with real-world expectations about "current day" data.

---

## **Related Issues**
- _None explicitly linked, but resolves a UX consistency issue around cache freshness._

---

## **Additional Notes**
- If you wish to remove the test commit later, consider squashing or rebasing before merge.
- This is ready for review and deployment.