### PR TITLE
refactor(theme): centralize theme config using defaultTheme

### DIFF
--- a/lib/core/theme/app_elevated_button_theme.dart
+++ b/lib/core/theme/app_elevated_button_theme.dart
@@ -2,6 +2,8 @@ import 'dart:ui';
 
 import 'package:flutter/material.dart';
 
+import 'app_theme.dart';
+
 class AppElevatedButtonTheme extends ThemeExtension<AppElevatedButtonTheme> {
   final Color backgroundColor;
   final Color textColor;
@@ -101,4 +103,25 @@ class AppElevatedButtonTheme extends ThemeExtension<AppElevatedButtonTheme> {
       textStyle: TextStyle.lerp(textStyle, other.textStyle, t)!,
     );
   }
+
+  static const defaultTheme = AppElevatedButtonTheme(
+    backgroundColor: AppTheme.primaryColor,
+    textColor: Colors.white,
+    baseColor: Color(0xFFE0E0E0),
+    lightShadowColor: Colors.white,
+    darkShadowColor: Color(0xFFA3B1C6),
+    borderRadius: 30.0,
+    elevation: 12.0,
+    shadowBlurRadius: 15.0,
+    pressedBlurRadius: 8.0,
+    pressedScale: 0.96,
+    pressDuration: Duration(milliseconds: 100),
+    shadowOffset: Offset(5, 5),
+    pressedShadowOffset: Offset(-5, -5),
+    minimumSize: Size(200, 50),
+    textStyle: TextStyle(
+      fontSize: 18,
+      fontWeight: FontWeight.bold,
+    ),
+  );
 }

--- a/lib/core/theme/app_theme.dart
+++ b/lib/core/theme/app_theme.dart
@@ -42,13 +42,7 @@ class AppTheme {
       foregroundColor: Colors.white,
     ),
     extensions: <ThemeExtension<dynamic>>[
-      const TodayWeatherCardTheme(
-        backgroundColor: Color(0xFF2C2C2E),
-        shape: RoundedRectangleBorder(
-          borderRadius: BorderRadius.all(Radius.circular(16)),
-        ),
-        padding: EdgeInsets.all(16),
-      ),
+      TodayWeatherCardTheme.defaultTheme,
       DailyForecastCardTheme.defaultTheme,
       const AppElevatedButtonTheme(
         backgroundColor: AppTheme.primaryColor,

--- a/lib/core/theme/app_theme.dart
+++ b/lib/core/theme/app_theme.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:google_fonts/google_fonts.dart';
 
 import 'app_elevated_button_theme.dart';
+import 'daily_forecast_card_theme.dart';
 import 'today_weather_card_theme.dart';
 
 /// アプリケーション全体のテーマ設定を提供します。
@@ -48,6 +49,7 @@ class AppTheme {
         ),
         padding: EdgeInsets.all(16),
       ),
+      DailyForecastCardTheme.defaultTheme,
       const AppElevatedButtonTheme(
         backgroundColor: AppTheme.primaryColor,
         textColor: Colors.white,

--- a/lib/core/theme/app_theme.dart
+++ b/lib/core/theme/app_theme.dart
@@ -44,26 +44,7 @@ class AppTheme {
     extensions: <ThemeExtension<dynamic>>[
       TodayWeatherCardTheme.defaultTheme,
       DailyForecastCardTheme.defaultTheme,
-      const AppElevatedButtonTheme(
-        backgroundColor: AppTheme.primaryColor,
-        textColor: Colors.white,
-        baseColor: Color(0xFFE0E0E0),
-        lightShadowColor: Colors.white,
-        darkShadowColor: Color(0xFFA3B1C6),
-        borderRadius: 30.0,
-        elevation: 12.0,
-        shadowBlurRadius: 15.0,
-        pressedBlurRadius: 8.0,
-        pressedScale: 0.96,
-        pressDuration: Duration(milliseconds: 100),
-        shadowOffset: Offset(5, 5),
-        pressedShadowOffset: Offset(-5, -5),
-        minimumSize: Size(200, 50),
-        textStyle: TextStyle(
-          fontSize: 18,
-          fontWeight: FontWeight.bold,
-        ),
-      ),
+      AppElevatedButtonTheme.defaultTheme,
     ],
   );
 }

--- a/lib/core/theme/daily_forecast_card_theme.dart
+++ b/lib/core/theme/daily_forecast_card_theme.dart
@@ -1,0 +1,78 @@
+import 'package:flutter/material.dart';
+
+class DailyForecastCardTheme extends ThemeExtension<DailyForecastCardTheme> {
+  final Color cardColor;
+  final ShapeBorder cardShape;
+  final EdgeInsets cardPadding;
+  final TextStyle dayLabelStyle;
+  final TextStyle tempRangeStyle;
+  final TextStyle descriptionStyle;
+
+  const DailyForecastCardTheme({
+    required this.cardColor,
+    required this.cardShape,
+    required this.cardPadding,
+    required this.dayLabelStyle,
+    required this.tempRangeStyle,
+    required this.descriptionStyle,
+  });
+
+  @override
+  DailyForecastCardTheme copyWith({
+    Color? cardColor,
+    ShapeBorder? cardShape,
+    EdgeInsets? cardPadding,
+    TextStyle? dayLabelStyle,
+    TextStyle? tempRangeStyle,
+    TextStyle? descriptionStyle,
+  }) {
+    return DailyForecastCardTheme(
+      cardColor: cardColor ?? this.cardColor,
+      cardShape: cardShape ?? this.cardShape,
+      cardPadding: cardPadding ?? this.cardPadding,
+      dayLabelStyle: dayLabelStyle ?? this.dayLabelStyle,
+      tempRangeStyle: tempRangeStyle ?? this.tempRangeStyle,
+      descriptionStyle: descriptionStyle ?? this.descriptionStyle,
+    );
+  }
+
+  @override
+  DailyForecastCardTheme lerp(
+      ThemeExtension<DailyForecastCardTheme>? other, double t) {
+    if (other is! DailyForecastCardTheme) return this;
+    return DailyForecastCardTheme(
+      cardColor: Color.lerp(cardColor, other.cardColor, t) ?? cardColor,
+      cardShape: cardShape,
+      cardPadding:
+          EdgeInsets.lerp(cardPadding, other.cardPadding, t) ?? cardPadding,
+      dayLabelStyle: TextStyle.lerp(dayLabelStyle, other.dayLabelStyle, t) ??
+          dayLabelStyle,
+      tempRangeStyle: TextStyle.lerp(tempRangeStyle, other.tempRangeStyle, t) ??
+          tempRangeStyle,
+      descriptionStyle:
+          TextStyle.lerp(descriptionStyle, other.descriptionStyle, t) ??
+              descriptionStyle,
+    );
+  }
+
+  static const defaultTheme = DailyForecastCardTheme(
+    cardColor: Color(0xFF2C2C2E),
+    cardShape: RoundedRectangleBorder(
+      borderRadius: BorderRadius.all(Radius.circular(16)),
+    ),
+    cardPadding: EdgeInsets.symmetric(horizontal: 12, vertical: 12),
+    dayLabelStyle: TextStyle(
+      color: Colors.white,
+      fontSize: 16,
+      fontWeight: FontWeight.w500,
+    ),
+    tempRangeStyle: TextStyle(
+      color: Colors.white70,
+      fontSize: 14,
+    ),
+    descriptionStyle: TextStyle(
+      color: Colors.white,
+      fontSize: 13,
+    ),
+  );
+}

--- a/lib/core/theme/today_weather_card_theme.dart
+++ b/lib/core/theme/today_weather_card_theme.dart
@@ -1,14 +1,14 @@
 import 'package:flutter/material.dart';
 
 class TodayWeatherCardTheme extends ThemeExtension<TodayWeatherCardTheme> {
-  final Color backgroundColor;
-  final ShapeBorder shape;
-  final EdgeInsets padding;
+  final Color backgroundCardColor;
+  final ShapeBorder cardShape;
+  final EdgeInsets cardPadding;
 
   const TodayWeatherCardTheme({
-    required this.backgroundColor,
-    required this.shape,
-    required this.padding,
+    required this.backgroundCardColor,
+    required this.cardShape,
+    required this.cardPadding,
   });
 
   @override
@@ -18,9 +18,9 @@ class TodayWeatherCardTheme extends ThemeExtension<TodayWeatherCardTheme> {
     EdgeInsets? padding,
   }) =>
       TodayWeatherCardTheme(
-        backgroundColor: backgroundColor ?? this.backgroundColor,
-        shape: shape ?? this.shape,
-        padding: padding ?? this.padding,
+        backgroundCardColor: backgroundColor ?? backgroundCardColor,
+        cardShape: shape ?? cardShape,
+        cardPadding: padding ?? cardPadding,
       );
 
   @override
@@ -30,9 +30,18 @@ class TodayWeatherCardTheme extends ThemeExtension<TodayWeatherCardTheme> {
       return this;
     }
     return TodayWeatherCardTheme(
-      backgroundColor: Color.lerp(backgroundColor, other.backgroundColor, t)!,
-      shape: shape,
-      padding: EdgeInsets.lerp(padding, other.padding, t)!,
+      backgroundCardColor:
+          Color.lerp(backgroundCardColor, other.backgroundCardColor, t)!,
+      cardShape: cardShape,
+      cardPadding: EdgeInsets.lerp(cardPadding, other.cardPadding, t)!,
     );
   }
+
+  static const defaultTheme = TodayWeatherCardTheme(
+    backgroundCardColor: Color(0xFF2C2C2E),
+    cardShape: RoundedRectangleBorder(
+      borderRadius: BorderRadius.all(Radius.circular(16)),
+    ),
+    cardPadding: EdgeInsets.all(16),
+  );
 }

--- a/lib/ui/weather/widgets/daily_forecast_card.dart
+++ b/lib/ui/weather/widgets/daily_forecast_card.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 
+import '../../../core/theme/daily_forecast_card_theme.dart';
 import 'daily_forecast_row.dart';
 
 class DailyForecastCard extends StatelessWidget {
@@ -12,12 +13,14 @@ class DailyForecastCard extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final theme = Theme.of(context).extension<DailyForecastCardTheme>()!;
+
     return Card(
-      color: Colors.grey[850],
-      shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(16)),
+      color: theme.cardColor,
+      shape: theme.cardShape,
       margin: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
       child: Padding(
-        padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 12),
+        padding: theme.cardPadding,
         child: Column(
           children: forecastRows,
         ),

--- a/lib/ui/weather/widgets/daily_forecast_row.dart
+++ b/lib/ui/weather/widgets/daily_forecast_row.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:gap/gap.dart';
 
+import '../../../core/theme/daily_forecast_card_theme.dart';
 import 'weather_icon.dart';
 
 class DailyForecastRow extends StatelessWidget {
@@ -21,6 +22,8 @@ class DailyForecastRow extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final theme = Theme.of(context).extension<DailyForecastCardTheme>()!;
+
     return Padding(
       padding: const EdgeInsets.symmetric(vertical: 6.0),
       child: Row(
@@ -38,19 +41,12 @@ class DailyForecastRow extends StatelessWidget {
               children: [
                 Text(
                   dayLabel,
-                  style: const TextStyle(
-                    color: Colors.white,
-                    fontSize: 16,
-                    fontWeight: FontWeight.w500,
-                  ),
+                  style: theme.dayLabelStyle,
                 ),
                 const Gap(4),
                 Text(
                   'Min: ${minTemperature.floor()}°C  Max: ${maxTemperature.floor()}°C',
-                  style: const TextStyle(
-                    color: Colors.white70,
-                    fontSize: 14,
-                  ),
+                  style: theme.tempRangeStyle,
                 ),
               ],
             ),
@@ -61,7 +57,7 @@ class DailyForecastRow extends StatelessWidget {
               alignment: Alignment.centerRight,
               child: Text(
                 description,
-                style: const TextStyle(color: Colors.white, fontSize: 13),
+                style: theme.descriptionStyle,
               ),
             ),
           ),

--- a/lib/ui/weather/widgets/today_weather_card.dart
+++ b/lib/ui/weather/widgets/today_weather_card.dart
@@ -29,14 +29,14 @@ class TodayWeatherCard extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final cardTheme = Theme.of(context).extension<TodayWeatherCardTheme>()!;
+    final theme = Theme.of(context).extension<TodayWeatherCardTheme>()!;
 
     return Card(
-      color: cardTheme.backgroundColor,
-      shape: cardTheme.shape,
+      color: theme.backgroundCardColor,
+      shape: theme.cardShape,
       margin: const EdgeInsets.symmetric(horizontal: 16),
       child: Padding(
-        padding: cardTheme.padding,
+        padding: theme.cardPadding,
         child: Column(
           mainAxisSize: MainAxisSize.min,
           crossAxisAlignment: CrossAxisAlignment.center,


### PR DESCRIPTION
## **Description**
This pull request refactors theme-related code by introducing centralized `defaultTheme` instances for `TodayWeatherCardTheme`, `DailyForecastCardTheme`, and `AppElevatedButtonTheme`. 
This improves consistency, reusability, and maintainability of the UI styling across the app.

---

## **Key Changes**
1. **Added `defaultTheme` to TodayWeatherCardTheme**: Extracted inline configuration into a reusable constant.
2. **Added `defaultTheme` to DailyForecastCardTheme**: Consolidated card, text styles, and padding.
3. **Added `defaultTheme` to AppElevatedButtonTheme**: Standardized button styling via theme extension.
4. **Refactored `AppTheme.lightTheme`** to use `defaultTheme` references instead of inline definitions.

---

## **Files Added**
- `lib/core/theme/daily_forecast_card_theme.dart`: Defines centralized forecast card styles via `ThemeExtension`.

---

## **Files Modified**
- **`lib/core/theme/today_weather_card_theme.dart`**: Added `defaultTheme` constant.
- **`lib/core/theme/app_elevated_button_theme.dart`**: Added `defaultTheme` constant.
- **`lib/core/theme/app_theme.dart`**: Replaced inline `ThemeExtension` definitions with `defaultTheme` constants.

---

## **How to Test**
1. **Manual Testing:**
- [ ] Launch the app.
- [ ] Navigate to a screen displaying `TodayWeatherCard`, `DailyForecastCard`, or an elevated button.
- [ ] Confirm that styles render correctly and consistently with previous design.

2. **Automated Testing:**
- Ensure that all existing tests pass.
- No new tests were required for this refactor (UI behavior unchanged).

---

## **Benefits**
- **Code Maintainability**: Theme configuration is now centralized, making updates and reuse much easier.
- **Improved Consistency**: Styling across components is uniform and scalable.
- **Preparation for Theme Scaling**: Easier to add `lightTheme`/`darkTheme` variations in the future.

---

## **Screenshots (if applicable)**
- N/A

---

## **Related Issues**
- N/A

---

## **Additional Notes**
- Consider applying the same `defaultTheme` pattern to other custom `ThemeExtension`s for consistency.