### PR TITLE
Reduce weather data cache interval from 6 hours to 1 hour

### DIFF
--- a/functions/src/weather_controller.ts
+++ b/functions/src/weather_controller.ts
@@ -10,8 +10,7 @@ interface WeatherRequest {
   city: string;
 }
 
-// キャッシュ有効時間（6時間 = 6 * 60分 * 60秒）
-const CACHE_DURATION_SECONDS = 6 * 60 * 60;
+const CACHE_DURATION_SECONDS = 1 * 60 * 60; // 1時間（3600秒）
 
 /**
  * 都市の天気を取得するCloud Function


### PR DESCRIPTION
## **Description**
This pull request updates the weather data caching logic in the Cloud Function to reduce the cache duration from 6 hours to 1 hour. This allows users to receive more up-to-date weather data while balancing API usage.

---

## **Key Changes**
1. **Feature**: Modified `CACHE_DURATION_SECONDS` from 6 hours to 1 hour for more frequent weather updates.
2. **Behavioral Change**: The function now fetches fresh data from the API if cache is older than 1 hour.
3. **Code Consistency**: Comments and logic updated to reflect the new interval.

---

## **Files Added**
- _No new files added in this PR._

---

## **Files Modified**
- **`functions/src/weather_controller.ts`**: Updated `CACHE_DURATION_SECONDS` and relevant comments/logic for cache expiry check.

---

## **How to Test**
1. **Manual Testing:**
- [ ] Deploy updated function using `firebase deploy --only functions`.
- [ ] Call the `getWeatherForCity` function via client or emulator.
- [ ] Confirm that weather data is fetched from API if more than 1 hour old.

2. **Automated Testing:**
- Ensure all existing Firebase function unit tests (if any) still pass.
- If applicable, add test coverage for 1-hour expiry logic.

---

## **Benefits**
- **Improved UX**: Users receive fresher weather data, enhancing reliability.
- **Code Maintainability**: Clearer logic for caching thresholds.
- **Performance/Balance**: Better control over API call frequency and Firestore usage.

---

## **Screenshots (if applicable)**
_N/A_

---

## **Related Issues**
- N/A

---

## **Additional Notes**
- If API usage increases significantly, consider implementing adaptive caching or per-city refresh policies.